### PR TITLE
more compatibility fixes for s3cmd

### DIFF
--- a/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
@@ -985,7 +985,10 @@ final class S3ProxyHandler extends AbstractHandler {
                 .append(Strings.nullToEmpty(request.getHeader(
                         HttpHeaders.CONTENT_TYPE)))
                 .append('\n');
-        if (!canonicalizedHeaders.containsKey("x-amz-date")) {
+        String expires = request.getParameter("Expires");
+        if (expires != null) {
+            builder.append(expires);
+        } else if (!canonicalizedHeaders.containsKey("x-amz-date")) {
             builder.append(request.getHeader(HttpHeaders.DATE));
         }
         builder.append('\n');


### PR DESCRIPTION
s3cmd uses virtual hostname for bucket name, with the host header
including the port. need to strip out the port to find out the
bucket name

also includes a small fix for x-amz-date, according to the
documentation we should always use empty string for date
when x-amz-date is included
