### PR TITLE
Update Dockerfile to use multistage building.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,22 @@
-FROM anapsix/alpine-java:jre7
+# Multistage - Builder
+FROM maven:3.5.0-jdk-7-alpine as s3proxy-builder
 MAINTAINER Andrew Gaul <andrew@gaul.org>
 
 WORKDIR /opt/s3proxy
+COPY . /opt/s3proxy/
+
+RUN mvn package
+
+# Multistage - Image
+FROM java:7u121-jre-alpine
+MAINTAINER Andrew Gaul <andrew@gaul.org>
+
+WORKDIR /opt/s3proxy
+
 COPY \
-    target/s3proxy \
-    src/main/resources/run-docker-container.sh \
+    --from=s3proxy-builder \
+    /opt/s3proxy/target/s3proxy \
+    /opt/s3proxy/src/main/resources/run-docker-container.sh \
     /opt/s3proxy/
 
 ENV \


### PR DESCRIPTION
This allows developers and users to build their own version of s3proxy fully in Docker without the need of external builders for the s3proxy binary.

This pull depends on features that have been recently released in the [17.05](https://github.com/moby/moby/blob/17.05.x/CHANGELOG.md#builder) version of Docker which may not be preferable for some older build environments.