### PR TITLE
v2/v4 auth improve

### DIFF
--- a/src/main/java/org/gaul/s3proxy/S3ErrorCode.java
+++ b/src/main/java/org/gaul/s3proxy/S3ErrorCode.java
@@ -79,7 +79,10 @@ enum S3ErrorCode {
             "At least one of the preconditions you specified did not hold."),
     REQUEST_TIME_TOO_SKEWED(HttpServletResponse.SC_FORBIDDEN, "Forbidden"),
     REQUEST_TIMEOUT(HttpServletResponse.SC_BAD_REQUEST, "Bad Request"),
-    SIGNATURE_DOES_NOT_MATCH(HttpServletResponse.SC_FORBIDDEN, "Forbidden");
+    SIGNATURE_DOES_NOT_MATCH(HttpServletResponse.SC_FORBIDDEN, "Forbidden"),
+    X_AMZ_CONTENT_S_H_A_256_MISMATCH(HttpServletResponse.SC_BAD_REQUEST,
+            "The provided 'x-amz-content-sha256' header does not match what" +
+            " was computed.");
 
     private final String errorCode;
     private final int httpStatusCode;

--- a/src/main/java/org/gaul/s3proxy/S3ProxyConstants.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyConstants.java
@@ -16,6 +16,8 @@
 
 package org.gaul.s3proxy;
 
+import java.util.concurrent.TimeUnit;
+
 public final class S3ProxyConstants {
     public static final String PROPERTY_ENDPOINT =
             "s3proxy.endpoint";
@@ -72,6 +74,8 @@ public final class S3ProxyConstants {
     /** Prevent mutations. */
     public static final String PROPERTY_READ_ONLY_BLOBSTORE =
             "s3proxy.read-only-blobstore";
+
+    public static final long PROPERTY_TIMESKEW = TimeUnit.MINUTES.toSeconds(15);
 
     static final String PROPERTY_ALT_JCLOUDS_PREFIX = "alt.";
 


### PR DESCRIPTION
* 15 minitues timeskew
* Add x-amz-date header or query parameter check
* Change the timeskew logic to first get client req auth type
* When v2,x-amz-date header format is rfc2616,when v4,is iso8601
* If have both x-amz-date header and date header,date value in
  stringtosign is x-amz-date header value,CanonicalizedAmzHeaders
  have no x-amz-header.
  Ref Delete example in site:
  http://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html
* Fix v2 query auth:
  If expires is nil ,does not mean that the auth type is not queryauth type.
  Ref http://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html#RESTAuthenticationQueryStringAuth
  It says that 'Additionally, you can limit a pre-signed request by specifying an expiration time.'