### PR TITLE
shading guava/jclouds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ s3proxy.iml
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 target/
+
+#maven shade plugin
+dependency-reduced-pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -156,10 +156,26 @@
               <goal>shade</goal>
             </goals>
             <configuration>
-             <createDependencyReducedPom>false</createDependencyReducedPom>
-             <artifactSet>
+              <createDependencyReducedPom>true</createDependencyReducedPom>
+              <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                  <resource>META-INF/services/org.jclouds.providers.ProviderMetadata</resource>
+                </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                  <resource>META-INF/services/org.jclouds.apis.ApiMetadata</resource>
+                </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                  <resource>META-INF/services/org.jclouds.logging.config.LoggingModule</resource>
+                </transformer>
+              </transformers>
+              <artifactSet>
                 <includes>
                   <include>org.eclipse.jetty:*</include>
+                  <include>com.google.guava:guava</include>
+                  <include>org.apache.jclouds:*</include>
+                  <include>org.apache.jclouds.api:*</include>
+                  <include>org.apache.jclouds.provider:*</include>
                 </includes>
               </artifactSet>
               <relocations>
@@ -167,11 +183,15 @@
                   <pattern>org.eclipse.jetty</pattern>
                   <shadedPattern>${shade.prefix}.org.eclipse.jetty</shadedPattern>
                 </relocation>
+                <relocation>
+                  <pattern>com.google.common</pattern>
+                  <shadedPattern>${shade.prefix}.com.google.common</shadedPattern>
+                </relocation>
               </relocations>
             </configuration>
           </execution>
         </executions>
-      </plugin>      
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
@@ -364,6 +384,11 @@
       <version>3.0.2</version>
     </dependency>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>18.0</version>
+    </dependency>
+    <dependency>
       <groupId>commons-fileupload</groupId>
       <artifactId>commons-fileupload</artifactId>
       <version>1.3.3</version>
@@ -371,6 +396,21 @@
     <dependency>
       <groupId>org.apache.jclouds</groupId>
       <artifactId>jclouds-allblobstore</artifactId>
+      <version>${jclouds.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds</groupId>
+      <artifactId>jclouds-core</artifactId>
+      <version>${jclouds.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds.api</groupId>
+      <artifactId>s3</artifactId>
+      <version>${jclouds.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds.provider</groupId>
+      <artifactId>aws-s3</artifactId>
       <version>${jclouds.version}</version>
     </dependency>
     <dependency>

--- a/src/main/assembly/jar-with-dependencies.xml
+++ b/src/main/assembly/jar-with-dependencies.xml
@@ -15,6 +15,10 @@
     <dependencySet>
       <excludes>
         <exclude>org.eclipse.jetty:*</exclude>
+        <exclude>com.google.guava:guava</exclude>
+        <exclude>org.apache.jclouds:*</exclude>
+        <exclude>org.apache.jclouds.api:*</exclude>
+        <exclude>org.apache.jclouds.provider:*</exclude>
       </excludes>
       <outputDirectory>/</outputDirectory>
       <useProjectArtifact>true</useProjectArtifact>


### PR DESCRIPTION
Hi :)
Following discussions here: https://issues.apache.org/jira/browse/JCLOUDS-1225 and here: https://github.com/gaul/s3proxy/issues/209
I made this PR that shades jclouds and shades/relocates guava. Our issue, as @massdosage described in JCLOUDS-1225, is that we got a dependency on hadoop which is on a rather old guava version conflicting with what s3proxy pulls in.

Following the Jetty shading I've went for a similar solution with guava. I'll add some inline comments with explanations.

Happy to have a discussion or make any changes.
