### PR TITLE
update depcrecated image, fix minor Label change

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Multistage - Builder
 FROM maven:3.5.0-jdk-7-alpine as s3proxy-builder
-MAINTAINER Andrew Gaul <andrew@gaul.org>
+LABEL maintainer="Andrew Gaul <andrew@gaul.org>"
 
 WORKDIR /opt/s3proxy
 COPY . /opt/s3proxy/
@@ -8,8 +8,8 @@ COPY . /opt/s3proxy/
 RUN mvn package -DskipTests
 
 # Multistage - Image
-FROM java:7u121-jre-alpine
-MAINTAINER Andrew Gaul <andrew@gaul.org>
+FROM openjdk:7-jre-alpine
+LABEL maintainer="Andrew Gaul <andrew@gaul.org>"
 
 WORKDIR /opt/s3proxy
 


### PR DESCRIPTION
Java is deprecated as the state:
"This image is officially deprecated in favor of the openjdk image, and will receive no further updates after 2016-12-31 (Dec 31, 2016). Please adjust your usage accordingly."

I adjusted it to the corresponding 7-alpine-jre tag  from openjdk
https://hub.docker.com/_/openjdk/

the MAINTAINER instruction is deprecated as of Docker Version: 
1.13.0
https://docs.docker.com/engine/deprecated/#maintainer-in-dockerfile

all the best