### PR TITLE
Allow setting property jclouds.regions via env variables when running in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ ENV \
     JCLOUDS_PROVIDER="filesystem" \
     JCLOUDS_ENDPOINT="" \
     JCLOUDS_REGION="" \
+    JCLOUDS_REGIONS="us-east-1" \
     JCLOUDS_IDENTITY="remote-identity" \
     JCLOUDS_CREDENTIAL="remote-credential"
 

--- a/src/main/resources/run-docker-container.sh
+++ b/src/main/resources/run-docker-container.sh
@@ -14,6 +14,7 @@ exec java \
     -Djclouds.credential=${JCLOUDS_CREDENTIAL} \
     -Djclouds.endpoint=${JCLOUDS_ENDPOINT} \
     -Djclouds.region=${JCLOUDS_REGION} \
+    -Djclouds.regions=${JCLOUDS_REGIONS} \
     -Djclouds.filesystem.basedir=/data \
     -jar /opt/s3proxy/s3proxy \
     --properties /dev/null


### PR DESCRIPTION
Also, default to`jcloud.regions=us-east-1` to avoid issues with the nodejs aws sdk like the one described in #202.