### PR TITLE
Keystone v3 support with properties

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,10 @@ ENV \
     JCLOUDS_REGION="" \
     JCLOUDS_REGIONS="us-east-1" \
     JCLOUDS_IDENTITY="remote-identity" \
-    JCLOUDS_CREDENTIAL="remote-credential"
+    JCLOUDS_CREDENTIAL="remote-credential" \
+    JCLOUDS_KEYSTONE_VERSION="" \
+    JCLOUDS_KEYSTONE_SCOPE="" \
+    JCLOUDS_KEYSTONE_PROJECT_DOMAIN_NAME=""
 
 EXPOSE 80
 VOLUME /data

--- a/src/main/resources/run-docker-container.sh
+++ b/src/main/resources/run-docker-container.sh
@@ -15,6 +15,9 @@ exec java \
     -Djclouds.endpoint=${JCLOUDS_ENDPOINT} \
     -Djclouds.region=${JCLOUDS_REGION} \
     -Djclouds.regions=${JCLOUDS_REGIONS} \
+    -Djclouds.keystone.version=${JCLOUDS_KEYSTONE_VERSION} \
+    -Djclouds.keystone.scope=${JCLOUDS_KEYSTONE_SCOPE} \
+    -Djclouds.keystone.project-domain-name=${JCLOUDS_KEYSTONE_PROJECT_DOMAIN_NAME} \
     -Djclouds.filesystem.basedir=/data \
     -jar /opt/s3proxy/s3proxy \
     --properties /dev/null


### PR DESCRIPTION
As already documented in the Wiki https://github.com/gaul/s3proxy/wiki/Storage-backend-examples#swift-keystone-v30, you can use a Swift backend with Keystone v3 authentification.
This PR makes the needed `jcloud` configuration options available in the Dockerfile and pass the environment as properties to the java runtime.