### PR TITLE
Adding libraries removed in Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -439,5 +439,21 @@
       <version>6.8.21</version>
       <scope>test</scope>
     </dependency>
+    <!-- adding libraries removed in java 11 to allow executing the jar -->
+    <dependency>
+        <groupId>com.sun.xml.bind</groupId>
+        <artifactId>jaxb-core</artifactId>
+        <version>2.2.11</version>
+    </dependency>
+    <dependency>
+        <groupId>com.sun.xml.bind</groupId>
+        <artifactId>jaxb-impl</artifactId>
+        <version>2.2.11</version>
+    </dependency>
+    <dependency>
+        <groupId>javax.activation</groupId>
+        <artifactId>activation</artifactId>
+        <version>1.1.1</version>
+    </dependency>    
   </dependencies>
 </project>


### PR DESCRIPTION
Please see this SO answer for details: https://stackoverflow.com/a/43574427 
Adding these libraries allows to build s3proxy on Java8 and run it on Java11.
Without these libraries, I was unable to start s3proxy.