### PR TITLE
Fix for OVH swift storage (url mismatch for region)

### DIFF
--- a/src/main/java/org/gaul/s3proxy/Main.java
+++ b/src/main/java/org/gaul/s3proxy/Main.java
@@ -310,13 +310,13 @@ public final class Main {
         }
 
         BlobStoreContext context = builder.build(BlobStoreContext.class);
-	BlobStore blobStore;
-	if (region != null) {
-	        blobStore = ((RegionScopedBlobStoreContext) context)
+        BlobStore blobStore;
+        if (region != null) {
+            blobStore = ((RegionScopedBlobStoreContext) context)
                     .getBlobStore(region);
-	} else {
-		blobStore = context.getBlobStore();
-	}
+        } else {
+            blobStore = context.getBlobStore();
+        }
         return blobStore;
     }
 

--- a/src/main/java/org/gaul/s3proxy/Main.java
+++ b/src/main/java/org/gaul/s3proxy/Main.java
@@ -311,7 +311,8 @@ public final class Main {
 
         BlobStoreContext context = builder.build(BlobStoreContext.class);
         BlobStore blobStore;
-        if (region != null) {
+        if (context instanceof RegionScopedBlobStoreContext &&
+                region != null) {
             blobStore = ((RegionScopedBlobStoreContext) context)
                     .getBlobStore(region);
         } else {

--- a/src/main/java/org/gaul/s3proxy/Main.java
+++ b/src/main/java/org/gaul/s3proxy/Main.java
@@ -310,12 +310,13 @@ public final class Main {
         }
 
         BlobStoreContext context = builder.build(BlobStoreContext.class);
-        BlobStore blobStore = context.getBlobStore();
-        if (context instanceof RegionScopedBlobStoreContext &&
-                region != null) {
-            blobStore = ((RegionScopedBlobStoreContext) context)
+	BlobStore blobStore;
+	if (region != null) {
+	        blobStore = ((RegionScopedBlobStoreContext) context)
                     .getBlobStore(region);
-        }
+	} else {
+		blobStore = context.getBlobStore();
+	}
         return blobStore;
     }
 


### PR DESCRIPTION
I've tried to use the proxy for OVH swift storage and got the same problem as #81 . The main problem was that `BlobStore blobStore = context.getBlobStore();` tries to compare different endpoints basing on values of the dictionary returned by the OVH API and the JCLOUDS_ENDPOINT variable. It mismatches hardly and it's falling back to the first region, that is DE1.

`[s3proxy] W 03-05 23:32:53.312 main o.j.l.s.i.GetRegionIdMatchingProviderURIOrNull:74 |::] failed to find key for value https://auth.cloud.ovh.net/v3/ in {DE1=https://storage.de1.cloud.ovh.net/v1/AUTH_d443, UK1=https://storage.uk1.cloud.ovh.net/v1/AUTH_d443, WAW1=https://storage.waw1.cloud.ovh.net/v1/AUTH_d443, GRA5=https://storage.gra5.cloud.ovh.net/v1/AUTH_d443, BHS3=https://storage.bhs3.cloud.ovh.net/v1/AUTH_d443, SBG5=https://storage.sbg5.cloud.ovh.net/v1/AUTH_d443}; choosing first: DE1
`

I've managed to tune the code a little bit and it happened to fix my problem, now I can define proper region in JCLOUDS_REGION variable. (JCLOUDS_REGIONS also has to be filled and has to contain the chosen region).
Also it seem that all tests are passing, therefore, here is the PR.
