### PR TITLE
UploadPartCopy: Fail if improper source range.

### DIFF
--- a/src/main/java/org/gaul/s3proxy/S3Exception.java
+++ b/src/main/java/org/gaul/s3proxy/S3Exception.java
@@ -63,7 +63,7 @@ public final class S3Exception extends Exception {
 
     @Override
     public String getMessage() {
-        StringBuilder builder = new StringBuilder().append(error);
+        StringBuilder builder = new StringBuilder().append(super.getMessage());
         if (!elements.isEmpty()) {
             builder.append(" ").append(elements);
         }


### PR DESCRIPTION
S3Proxy should check the format of the x-amz-copy-source-range value
when handling an UploadPartCopy request. The patch changes the behavior
to return an InvalidArgument error along with the matching error
description to AWS S3. To match the error format, the S3Exception class
is modified to return the actual error message, rather than the String
version of the error code.

Corresponding tests will be added to ceph/s3-tests.

Fixes: #304