### PR TITLE
Fixes #299

### DIFF
--- a/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
@@ -844,7 +844,11 @@ public class S3ProxyHandler {
     }
 
     private void handleGetContainerAcl(HttpServletResponse response,
-            BlobStore blobStore, String containerName) throws IOException {
+            BlobStore blobStore, String containerName)
+            throws IOException, S3Exception {
+        if (!blobStore.containerExists(containerName)) {
+            throw new S3Exception(S3ErrorCode.NO_SUCH_BUCKET);
+        }
         ContainerAccess access = blobStore.getContainerAccess(containerName);
 
         response.setCharacterEncoding(UTF_8);

--- a/src/test/java/org/gaul/s3proxy/junit/S3ProxyRuleTest.java
+++ b/src/test/java/org/gaul/s3proxy/junit/S3ProxyRuleTest.java
@@ -87,4 +87,12 @@ public class S3ProxyRuleTest {
         assertThat(summaries.get(0).getSize()).isEqualTo(testInput.length());
     }
 
+    @Test
+    public final void doesBucketExistV2() {
+        assertThat(s3Client.doesBucketExistV2(MY_TEST_BUCKET)).isTrue();
+
+        // Issue #299
+        assertThat(s3Client.doesBucketExistV2("nonexistingbucket")).isFalse();
+    }
+
 }


### PR DESCRIPTION
Fixes #299 

Issue:
1. `AmazonS3Client#doesBucketExistV2(String bucketName)`
2. internally uses `AmazonS3Client#getBucketAcl(String bucketName)`
3. The `S3ProxyHandler` thew an exception on a GET Bucket ACL request for buckets that do not exist. 

Fixed it by making sure the `S3ProxyHandler` GET Bucket ACL correctly responds with a 404 if the bucket does not exist. 