### PR TITLE
Removed container root user requirement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ ENV \
 
 EXPOSE 8080
 VOLUME /data
+RUN chmod 775 /data
 USER 1001
 
 ENTRYPOINT ["/opt/s3proxy/run-docker-container.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,8 @@ ENV \
     JCLOUDS_KEYSTONE_SCOPE="" \
     JCLOUDS_KEYSTONE_PROJECT_DOMAIN_NAME=""
 
-EXPOSE 80
+EXPOSE 8080
 VOLUME /data
+USER 1001
 
 ENTRYPOINT ["/opt/s3proxy/run-docker-container.sh"]

--- a/src/main/resources/run-docker-container.sh
+++ b/src/main/resources/run-docker-container.sh
@@ -2,7 +2,7 @@
 
 exec java \
     -DLOG_LEVEL=${LOG_LEVEL} \
-    -Ds3proxy.endpoint=http://0.0.0.0:80 \
+    -Ds3proxy.endpoint=http://0.0.0.0:8080 \
     -Ds3proxy.virtual-host=${S3PROXY_VIRTUALHOST} \
     -Ds3proxy.authorization=${S3PROXY_AUTHORIZATION} \
     -Ds3proxy.identity=${S3PROXY_IDENTITY} \


### PR DESCRIPTION
The service will now listen on port 8080 with a regular UID.
The local /data volume can also be written to by this UID.

Tested in OpenShift.