### PR TITLE
CORS header for MultiPart Requests

### DIFF
--- a/src/test/java/org/gaul/s3proxy/CrossOriginResourceSharingRuleTest.java
+++ b/src/test/java/org/gaul/s3proxy/CrossOriginResourceSharingRuleTest.java
@@ -100,6 +100,12 @@ public final class CrossOriginResourceSharingRuleTest {
         probe = "GET";
         assertThat(corsAll.isMethodAllowed(probe))
                 .as("check '%s' as method", probe).isTrue();
+        probe = "PUT";
+        assertThat(corsAll.isMethodAllowed(probe))
+                .as("check '%s' as method", probe).isTrue();
+        probe = "POST";
+        assertThat(corsAll.isMethodAllowed(probe))
+                .as("check '%s' as method", probe).isTrue();
     }
 
     @Test


### PR DESCRIPTION
Adding CORS headers Access-Control-Allow-Origin and Access-Control-Allow-Methods in Multipart Responses if the
Origin Header is included in the Request and does match the CORS rules.
This was requested in #331.

Unfortunately my spare time is very limited at the moment and I was not able to write a test case for the multi part uploads. I tried, but there seems to be no easy way to retrieve the response Headers e.g. from InitiateMultipartUploadResult like here: https://github.com/gaul/s3proxy/blob/master/src/test/java/org/gaul/s3proxy/AwsSdkTest.java#L481-L482 to verify that CORS headers are present.

So maybe some else could step in here and add a test.

I am sorry that I cannot provide more in the moment.

Super-seeds #332 