### PR TITLE
Use the old environment variable for virtual host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ ENV \
     S3PROXY_ENDPOINT="http://0.0.0.0:80" \
     S3PROXY_IDENTITY="local-identity" \
     S3PROXY_CREDENTIAL="local-credential" \
-    S3PROXY_VIRTUAL_HOST="" \
+    S3PROXY_VIRTUALHOST="" \
     S3PROXY_CORS_ALLOW_ALL="false" \
     S3PROXY_CORS_ALLOW_ORIGINS="" \
     S3PROXY_CORS_ALLOW_METHODS="" \

--- a/src/main/resources/run-docker-container.sh
+++ b/src/main/resources/run-docker-container.sh
@@ -7,7 +7,6 @@ exec java \
     -Ds3proxy.authorization="${S3PROXY_AUTHORIZATION}" \
     -Ds3proxy.identity="${S3PROXY_IDENTITY}" \
     -Ds3proxy.credential="${S3PROXY_CREDENTIAL}" \
-    -Ds3proxy.virtual-host="${S3PROXY_VIRTUAL_HOST}" \
     -Ds3proxy.cors-allow-all="${S3PROXY_CORS_ALLOW_ALL}" \
     -Ds3proxy.cors-allow-origins="${S3PROXY_CORS_ALLOW_ORIGINS}" \
     -Ds3proxy.cors-allow-methods="${S3PROXY_CORS_ALLOW_METHODS}" \


### PR DESCRIPTION
This project used the env var `S3PROXY_VIRTUALHOST`, but then this PR: #341 added another declaration that used `S3PROXY_VIRTUAL_HOST`.

This PR fixes this, and goes back to `S3PROXY_VIRTUALHOST`.


Thanks !
