### PR TITLE
Better support for caching scenarios of CORS responses

### DIFF
--- a/src/main/java/org/gaul/s3proxy/CrossOriginResourceSharing.java
+++ b/src/main/java/org/gaul/s3proxy/CrossOriginResourceSharing.java
@@ -34,7 +34,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 final class CrossOriginResourceSharing {
-    public static final Collection<String> SUPPORTED_METHODS =
+    protected static final Collection<String> SUPPORTED_METHODS =
             ImmutableList.of("GET", "PUT", "POST");
 
     private static final String HEADER_VALUE_SEPARATOR = ", ";

--- a/src/main/java/org/gaul/s3proxy/CrossOriginResourceSharing.java
+++ b/src/main/java/org/gaul/s3proxy/CrossOriginResourceSharing.java
@@ -26,6 +26,7 @@ import java.util.regex.Pattern;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 
@@ -33,6 +34,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 final class CrossOriginResourceSharing {
+    public static final Collection<String> SUPPORTED_METHODS =
+            ImmutableList.of("GET", "PUT", "POST", "HEAD");
+
     private static final String HEADER_VALUE_SEPARATOR = ", ";
     private static final String ALLOW_ANY_HEADER = "*";
 
@@ -47,7 +51,7 @@ final class CrossOriginResourceSharing {
 
     protected CrossOriginResourceSharing() {
         // CORS Allow all
-        this(Lists.newArrayList(".*"), Lists.newArrayList("GET", "PUT", "POST"),
+        this(Lists.newArrayList(".*"), SUPPORTED_METHODS,
                 Lists.newArrayList(ALLOW_ANY_HEADER));
     }
 

--- a/src/main/java/org/gaul/s3proxy/S3Proxy.java
+++ b/src/main/java/org/gaul/s3proxy/S3Proxy.java
@@ -22,9 +22,11 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Collection;
 import java.util.Objects;
 import java.util.Properties;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
@@ -255,6 +257,18 @@ public final class S3Proxy {
                         S3ProxyConstants.PROPERTY_CORS_ALLOW_HEADERS, "");
                 Splitter splitter = Splitter.on(" ").trimResults()
                         .omitEmptyStrings();
+
+                //Validate configured methods
+                Collection<String> allowedMethods = Lists.newArrayList(
+                        splitter.split(corsAllowMethods));
+                allowedMethods.removeAll(
+                        CrossOriginResourceSharing.SUPPORTED_METHODS);
+                if (!allowedMethods.isEmpty()) {
+                    throw new IllegalArgumentException(
+                        S3ProxyConstants.PROPERTY_CORS_ALLOW_METHODS +
+                        " contains not supported values: " + Joiner.on(" ")
+                        .join(allowedMethods));
+                }
 
                 builder.corsRules(new CrossOriginResourceSharing(
                         Lists.newArrayList(splitter.split(corsAllowOrigins)),

--- a/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
@@ -1653,8 +1653,9 @@ public class S3ProxyHandler {
             }
         }
 
-        response.addHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, corsOrigin);
         response.addHeader(HttpHeaders.VARY, HttpHeaders.ORIGIN);
+        response.addHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN,
+                corsRules.getAllowedOrigin(corsOrigin));
         response.addHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS,
                 corsRules.getAllowedMethods());
 
@@ -2899,9 +2900,9 @@ public class S3ProxyHandler {
         if (!Strings.isNullOrEmpty(corsOrigin) &&
                 corsRules.isOriginAllowed(corsOrigin)) {
             response.addHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN,
-                    corsOrigin);
+                    corsRules.getAllowedOrigin(corsOrigin));
             response.addHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS,
-                    request.getMethod());
+                    corsRules.getAllowedMethods());
         }
     }
 

--- a/src/test/java/org/gaul/s3proxy/CrossOriginResourceSharingAllowAllResponseTest.java
+++ b/src/test/java/org/gaul/s3proxy/CrossOriginResourceSharingAllowAllResponseTest.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2014-2020 Andrew Gaul <andrew@gaul.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gaul.s3proxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.Date;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import javax.net.ssl.SSLContext;
+
+import com.amazonaws.HttpMethod;
+import com.amazonaws.SDKGlobalConfiguration;
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+
+import com.google.common.io.ByteSource;
+import com.google.common.net.HttpHeaders;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpOptions;
+import org.apache.http.config.Registry;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.apache.http.conn.socket.PlainConnectionSocketFactory;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.conn.ssl.TrustStrategy;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.apache.http.ssl.SSLContextBuilder;
+
+import org.jclouds.blobstore.BlobStoreContext;
+import org.jclouds.blobstore.domain.Blob;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public final class CrossOriginResourceSharingAllowAllResponseTest {
+    static {
+        System.setProperty(
+                SDKGlobalConfiguration.DISABLE_CERT_CHECKING_SYSTEM_PROPERTY,
+                "true");
+        AwsSdkTest.disableSslVerification();
+    }
+
+    private URI s3Endpoint;
+    private EndpointConfiguration s3EndpointConfig;
+    private S3Proxy s3Proxy;
+    private BlobStoreContext context;
+    private String containerName;
+    private AWSCredentials awsCreds;
+    private AmazonS3 s3Client;
+    private String servicePath;
+    private CloseableHttpClient httpClient;
+    private URI presignedGET;
+
+    @Before
+    public void setUp() throws Exception {
+        TestUtils.S3ProxyLaunchInfo info = TestUtils.startS3Proxy(
+                "s3proxy-cors-allow-all.conf");
+        awsCreds = new BasicAWSCredentials(info.getS3Identity(),
+                info.getS3Credential());
+        context = info.getBlobStore().getContext();
+        s3Proxy = info.getS3Proxy();
+        s3Endpoint = info.getSecureEndpoint();
+        servicePath = info.getServicePath();
+        s3EndpointConfig = new EndpointConfiguration(
+                s3Endpoint.toString() + servicePath, "us-east-1");
+        s3Client = AmazonS3ClientBuilder.standard()
+                .withCredentials(new AWSStaticCredentialsProvider(awsCreds))
+                .withEndpointConfiguration(s3EndpointConfig)
+                .build();
+        httpClient = getHttpClient();
+
+        containerName = createRandomContainerName();
+        info.getBlobStore().createContainerInLocation(null, containerName);
+
+        s3Client.setBucketAcl(containerName,
+                CannedAccessControlList.PublicRead);
+
+        String blobName = "test";
+        ByteSource payload = ByteSource.wrap("blob-content".getBytes(
+                StandardCharsets.UTF_8));
+        Blob blob = info.getBlobStore().blobBuilder(blobName)
+                .payload(payload).contentLength(payload.size()).build();
+        info.getBlobStore().putBlob(containerName, blob);
+
+        Date expiration = new Date(System.currentTimeMillis() +
+                TimeUnit.HOURS.toMillis(1));
+        presignedGET = s3Client.generatePresignedUrl(containerName, blobName,
+                expiration, HttpMethod.GET).toURI();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (s3Proxy != null) {
+            s3Proxy.stop();
+        }
+        if (context != null) {
+            context.getBlobStore().deleteContainer(containerName);
+            context.close();
+        }
+        if (httpClient != null) {
+            httpClient.close();
+        }
+    }
+
+    @Test
+    public void testCorsPreflight() throws Exception {
+        // Allowed origin, method and header combination
+        HttpOptions request = new HttpOptions(presignedGET);
+        request.setHeader(HttpHeaders.ORIGIN, "https://example.com");
+        request.setHeader(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "GET");
+        request.setHeader(HttpHeaders.ACCESS_CONTROL_REQUEST_HEADERS,
+                "Accept, Content-Type");
+        HttpResponse response = httpClient.execute(request);
+        assertThat(response.getStatusLine().getStatusCode())
+                .isEqualTo(HttpStatus.SC_OK);
+        assertThat(response.containsHeader(
+                HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN)).isTrue();
+        assertThat(response.getFirstHeader(
+                HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN).getValue())
+                .isEqualTo("*");
+        assertThat(response.containsHeader(
+                HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS)).isTrue();
+        assertThat(response.getFirstHeader(
+                HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS).getValue())
+                .isEqualTo("GET, PUT, POST");
+        assertThat(response.containsHeader(
+                HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS)).isTrue();
+        assertThat(response.getFirstHeader(
+                HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS).getValue())
+                .isEqualTo("Accept, Content-Type");
+    }
+
+    @Test
+    public void testCorsActual() throws Exception {
+        HttpGet request = new HttpGet(presignedGET);
+        request.setHeader(HttpHeaders.ORIGIN, "https://example.com");
+        HttpResponse response = httpClient.execute(request);
+        assertThat(response.getStatusLine().getStatusCode())
+                .isEqualTo(HttpStatus.SC_OK);
+        assertThat(response.containsHeader(
+                HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN)).isTrue();
+        assertThat(response.getFirstHeader(
+                HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN).getValue())
+                .isEqualTo("*");
+        assertThat(response.containsHeader(
+                HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS)).isTrue();
+        assertThat(response.getFirstHeader(
+                HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS).getValue())
+                    .isEqualTo("GET, PUT, POST");
+    }
+
+    @Test
+    public void testNonCors() throws Exception {
+        HttpGet request = new HttpGet(presignedGET);
+        HttpResponse response = httpClient.execute(request);
+        assertThat(response.getStatusLine().getStatusCode())
+                .isEqualTo(HttpStatus.SC_OK);
+        assertThat(response.containsHeader(
+                HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN)).isFalse();
+    }
+
+    private static String createRandomContainerName() {
+        return "s3proxy-" + new Random().nextInt(Integer.MAX_VALUE);
+    }
+
+    private static CloseableHttpClient getHttpClient() throws
+            KeyManagementException, NoSuchAlgorithmException,
+            KeyStoreException {
+        // Relax SSL Certificate check
+        SSLContext sslContext = new SSLContextBuilder().loadTrustMaterial(
+                null, new TrustStrategy() {
+                    @Override
+                    public boolean isTrusted(X509Certificate[] arg0,
+                            String arg1) throws CertificateException {
+                        return true;
+                    }
+                }).build();
+
+        Registry<ConnectionSocketFactory> registry = RegistryBuilder
+                .<ConnectionSocketFactory>create()
+                .register("http", PlainConnectionSocketFactory.INSTANCE)
+                .register("https", new SSLConnectionSocketFactory(sslContext,
+                NoopHostnameVerifier.INSTANCE)).build();
+
+        PoolingHttpClientConnectionManager connectionManager = new
+                PoolingHttpClientConnectionManager(registry);
+
+        return HttpClients.custom().setConnectionManager(connectionManager)
+                .build();
+    }
+}

--- a/src/test/java/org/gaul/s3proxy/CrossOriginResourceSharingResponseTest.java
+++ b/src/test/java/org/gaul/s3proxy/CrossOriginResourceSharingResponseTest.java
@@ -321,7 +321,7 @@ public final class CrossOriginResourceSharingResponseTest {
                 HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS)).isTrue();
         assertThat(response.getFirstHeader(
                 HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS).getValue())
-                    .isEqualTo("GET");
+                    .isEqualTo("GET, PUT");
     }
 
     @Test

--- a/src/test/resources/s3proxy-cors-allow-all.conf
+++ b/src/test/resources/s3proxy-cors-allow-all.conf
@@ -1,0 +1,16 @@
+s3proxy.endpoint=http://127.0.0.1:0
+s3proxy.secure-endpoint=https://127.0.0.1:0
+# authorization must be aws-v2, aws-v4, aws-v2-or-v4, or none
+s3proxy.authorization=aws-v2-or-v4
+s3proxy.identity=local-identity
+s3proxy.credential=local-credential
+s3proxy.keystore-path=keystore.jks
+s3proxy.keystore-password=password
+s3proxy.cors-allow-all=true
+
+jclouds.provider=transient
+jclouds.identity=remote-identity
+jclouds.credential=remote-credential
+# endpoint is optional for some providers
+#jclouds.endpoint=http://127.0.0.1:8081
+jclouds.filesystem.basedir=/tmp/blobstore


### PR DESCRIPTION
If the allowed origin `*` is configured e.g. through config option `s3proxy.cors-allow-all=true` the `ACCESS_CONTROL_ALLOW_ORIGIN` header in CORS responses will now always be `*` and not the requested host from the `Origin` header. If only concrete allowed origins are configured the behaviour remains unchanged.
Furthermore the `ACCESS_CONTROL_ALLOW_METHODS` header will always include all allowed methods in the CORS response.
This is inline with a native S3 CORS response and will help esp. in CDN caching scenarios. All requested Origins can be served with a cached response.

Further changes:
* S3Proxy only accepts allowed methods from `CrossOriginResourceSharing.SUPPORTED_METHODS`, preventing operators to configure methods which do not provide CORS headers atm, like `HEAD` or `DELETE`.
* If configured allowed origins contains `*` all other configured origins are skipped and are not pattern matched -> Allow any origin
* Testcase for `cors-allow-all=true` added

Closes #343 