### PR TITLE
Make CrossOriginResourceSharing public

### DIFF
--- a/src/main/java/org/gaul/s3proxy/CrossOriginResourceSharing.java
+++ b/src/main/java/org/gaul/s3proxy/CrossOriginResourceSharing.java
@@ -33,7 +33,7 @@ import com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-final class CrossOriginResourceSharing {
+public class CrossOriginResourceSharing {
     protected static final Collection<String> SUPPORTED_METHODS =
             ImmutableList.of("GET", "PUT", "POST");
 


### PR DESCRIPTION
I think cannot construct a S3ProxyHandler which is public without this class being public to pass to the constructor.