### PR TITLE
Make CORS handling optional

### DIFF
--- a/src/main/java/org/gaul/s3proxy/CrossOriginResourceSharing.java
+++ b/src/main/java/org/gaul/s3proxy/CrossOriginResourceSharing.java
@@ -33,9 +33,9 @@ import com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-final class CrossOriginResourceSharing {
+final  class CrossOriginResourceSharing {
     protected static final Collection<String> SUPPORTED_METHODS =
-            ImmutableList.of("GET", "PUT", "POST");
+            ImmutableList.of("GET", "HEAD", "PUT", "POST");
 
     private static final String HEADER_VALUE_SEPARATOR = ", ";
     private static final String ALLOW_ANY_ORIGIN = "*";

--- a/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
@@ -220,7 +220,8 @@ public class S3ProxyHandler {
             AuthenticationType authenticationType, final String identity,
             final String credential, @Nullable String virtualHost,
             long maxSinglePartObjectSize, long v4MaxNonChunkedRequestSize,
-            boolean ignoreUnknownHeaders, @Nullable CrossOriginResourceSharing corsRules,
+            boolean ignoreUnknownHeaders,
+            @Nullable CrossOriginResourceSharing corsRules,
             final String servicePath, int maximumTimeSkew) {
         if (corsRules != null) {
             this.corsRules = corsRules;

--- a/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
@@ -220,8 +220,13 @@ public class S3ProxyHandler {
             AuthenticationType authenticationType, final String identity,
             final String credential, @Nullable String virtualHost,
             long maxSinglePartObjectSize, long v4MaxNonChunkedRequestSize,
-            boolean ignoreUnknownHeaders, CrossOriginResourceSharing corsRules,
+            boolean ignoreUnknownHeaders, @Nullable CrossOriginResourceSharing corsRules,
             final String servicePath, int maximumTimeSkew) {
+        if (corsRules != null) {
+            this.corsRules = corsRules;
+        } else {
+            this.corsRules = new CrossOriginResourceSharing();
+        }
         if (authenticationType != AuthenticationType.NONE) {
             anonymousIdentity = false;
             blobStoreLocator = new BlobStoreLocator() {
@@ -252,7 +257,6 @@ public class S3ProxyHandler {
         this.maxSinglePartObjectSize = maxSinglePartObjectSize;
         this.v4MaxNonChunkedRequestSize = v4MaxNonChunkedRequestSize;
         this.ignoreUnknownHeaders = ignoreUnknownHeaders;
-        this.corsRules = corsRules;
         this.defaultBlobStore = blobStore;
         xmlOutputFactory.setProperty("javax.xml.stream.isRepairingNamespaces",
                 Boolean.FALSE);


### PR DESCRIPTION
This makes it possible to construct the S3ProxyHandler.  
Making the CrossOriginResourceSharing public with public constructors caused more CheckStyle errors because of all the finals.
In my testing with AWS client v2 I also had to add HEAD to the methods.