### PR TITLE
Allow differentiating blob stores by buckets

### DIFF
--- a/src/main/java/org/gaul/s3proxy/S3ProxyConstants.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyConstants.java
@@ -66,6 +66,18 @@ public final class S3ProxyConstants {
             "s3proxy.max-single-part-object-size";
     public static final String PROPERTY_V4_MAX_NON_CHUNKED_REQUEST_SIZE =
             "s3proxy.v4-max-non-chunked-request-size";
+    /** Used to locate blobstores by specified bucket names. Each property
+     * file should contain a list of buckets associated with it, e.g.
+     *     s3proxy.bucket-locator.1 = data
+     *     s3proxy.bucket-locator.2 = metadata
+     *     s3proxy.bucket-locator.3 = other
+     * When a request is made for the specified bucket, the backend defined
+     * in that properties file is used. This allows using the same
+     * credentials in multiple properties file and select the backend based
+     * on the bucket names.
+     */
+    public static final String PROPERTY_BUCKET_LOCATOR =
+            "s3proxy.bucket-locator";
     /** When true, model eventual consistency using two storage backends. */
     public static final String PROPERTY_EVENTUAL_CONSISTENCY =
             "s3proxy.eventual-consistency";


### PR DESCRIPTION
Allows differentiating the backend blob stores by configured buckets.
The commit allows using the same s3proxy credentials across the
different backends and relies on the bucket names to disambiguate them.

If no buckets are configured, the prior blob store selection algorithm
is used, which returns the first configured blob store for the specified
identity.

The patch supports the glob syntax, which allows specifying groups of
buckets more easily. However, there is no checking for overlapping
globs.

Fixes: #371