### PR TITLE
Fix a bug in blobstore locator

### DIFF
--- a/src/main/java/org/gaul/s3proxy/GlobBlobStoreLocator.java
+++ b/src/main/java/org/gaul/s3proxy/GlobBlobStoreLocator.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2014-2021 Andrew Gaul <andrew@gaul.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gaul.s3proxy;
+
+import java.nio.file.FileSystems;
+import java.nio.file.PathMatcher;
+import java.util.Map;
+
+import com.google.common.collect.Maps;
+
+import org.jclouds.blobstore.BlobStore;
+
+public final class GlobBlobStoreLocator implements BlobStoreLocator {
+    private final Map<String, Map.Entry<String, BlobStore>> locator;
+    private final Map<PathMatcher, Map.Entry<String, BlobStore>> globLocator;
+
+    public GlobBlobStoreLocator(
+            Map<String, Map.Entry<String, BlobStore>> locator,
+            Map<PathMatcher, Map.Entry<String, BlobStore>> globLocator) {
+        this.locator = locator;
+        this.globLocator = globLocator;
+    }
+
+    @Override
+    public Map.Entry<String, BlobStore> locateBlobStore(
+            String identity, String container, String blob) {
+        Map.Entry<String, BlobStore> locatorEntry =
+                locator.get(identity);
+        Map.Entry<String, BlobStore> globEntry = null;
+        for (Map.Entry<PathMatcher, Map.Entry<String, BlobStore>>
+                entry : globLocator.entrySet()) {
+            if (entry.getKey().matches(FileSystems.getDefault()
+                    .getPath(container))) {
+                globEntry = entry.getValue();
+            }
+        }
+        if (globEntry == null) {
+            if (identity == null) {
+                return locator.entrySet().iterator().next()
+                        .getValue();
+            }
+            return locatorEntry;
+        }
+        if (identity == null) {
+            return Maps.immutableEntry(null, globEntry.getValue());
+        }
+        if (!globEntry.getKey().equals(identity)) {
+            return null;
+        }
+        if (locatorEntry == null) {
+            return null;
+        }
+        return Maps.immutableEntry(locatorEntry.getKey(),
+                globEntry.getValue());
+    }
+}

--- a/src/test/java/org/gaul/s3proxy/GlobBlobStoreLocatorTest.java
+++ b/src/test/java/org/gaul/s3proxy/GlobBlobStoreLocatorTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2014-2021 Andrew Gaul <andrew@gaul.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gaul.s3proxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.FileSystems;
+import java.nio.file.PathMatcher;
+import java.util.Map;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.Maps;
+import com.google.inject.Module;
+
+import org.jclouds.ContextBuilder;
+import org.jclouds.blobstore.BlobStore;
+import org.jclouds.blobstore.BlobStoreContext;
+import org.jclouds.logging.slf4j.config.SLF4JLoggingModule;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public final class GlobBlobStoreLocatorTest {
+    private BlobStore blobStoreOne;
+    private BlobStore blobStoreTwo;
+
+    @Before
+    public void setUp() {
+        blobStoreOne = ContextBuilder
+                .newBuilder("transient")
+                .credentials("identity", "credential")
+                .modules(ImmutableList.<Module>of(new SLF4JLoggingModule()))
+                .build(BlobStoreContext.class).getBlobStore();
+        blobStoreTwo = ContextBuilder
+                .newBuilder("transient")
+                .credentials("identity", "credential")
+                .modules(ImmutableList.<Module>of(new SLF4JLoggingModule()))
+                .build(BlobStoreContext.class).getBlobStore();
+
+    }
+
+    @Test
+    public void testLocateIdentity() {
+        ImmutableMap<String, Map.Entry<String, BlobStore>> credsMap =
+                ImmutableSortedMap.of(
+                        "id1", Maps.immutableEntry("one", blobStoreOne),
+                        "id2", Maps.immutableEntry("two", blobStoreTwo));
+        GlobBlobStoreLocator locator = new GlobBlobStoreLocator(
+                credsMap, ImmutableMap.of());
+        assertThat(locator.locateBlobStore("id2", null, null).getKey())
+                .isEqualTo("two");
+        assertThat(locator.locateBlobStore(null, null, null).getKey())
+                .isEqualTo("one");
+        assertThat(locator.locateBlobStore("foo", null, null)).isNull();
+    }
+
+    @Test
+    public void testLocateContainer() {
+        ImmutableMap<String, Map.Entry<String, BlobStore>> credsMap =
+                ImmutableMap.of(
+                        "id1", Maps.immutableEntry("one", blobStoreOne),
+                        "id2", Maps.immutableEntry("two", blobStoreTwo));
+        ImmutableMap<PathMatcher, Map.Entry<String, BlobStore>> globMap =
+                ImmutableMap.of(
+                        FileSystems.getDefault().getPathMatcher(
+                                "glob:container1"),
+                        Maps.immutableEntry("id1", blobStoreOne),
+                        FileSystems.getDefault().getPathMatcher(
+                                "glob:container2"),
+                        Maps.immutableEntry("id2", blobStoreTwo)
+                );
+        GlobBlobStoreLocator locator = new GlobBlobStoreLocator(credsMap,
+                globMap);
+
+        assertThat(locator.locateBlobStore(null, "container1", null)
+                .getValue()).isSameAs(blobStoreOne);
+        assertThat(locator.locateBlobStore(null, "container2", null)
+                .getValue()).isSameAs(blobStoreTwo);
+        assertThat(locator.locateBlobStore("id1", "foo", null)
+                .getValue()).isSameAs(blobStoreOne);
+        assertThat(locator.locateBlobStore("id2", "foo", null)
+                .getValue()).isSameAs(blobStoreTwo);
+        assertThat(locator.locateBlobStore("foo", "container1", null))
+                .isNull();
+        assertThat(locator.locateBlobStore("foo", "container2", null))
+                .isNull();
+    }
+
+    @Test
+    public void testLocateGlob() {
+        ImmutableMap<String, Map.Entry<String, BlobStore>> credsMap =
+                ImmutableSortedMap.of(
+                        "id0", Maps.immutableEntry("zero", null),
+                        "id1", Maps.immutableEntry("one", blobStoreOne),
+                        "id2", Maps.immutableEntry("two", blobStoreTwo));
+        ImmutableMap<PathMatcher, Map.Entry<String, BlobStore>> globMap =
+                ImmutableMap.of(
+                        FileSystems.getDefault().getPathMatcher(
+                                "glob:{one,two}"),
+                        Maps.immutableEntry("id1", blobStoreOne),
+                        FileSystems.getDefault().getPathMatcher(
+                                "glob:cont?X*"),
+                        Maps.immutableEntry("id2", blobStoreTwo)
+                );
+        GlobBlobStoreLocator locator = new GlobBlobStoreLocator(credsMap,
+                globMap);
+
+        assertThat(locator.locateBlobStore(null, "one", null)
+                .getValue()).isSameAs(blobStoreOne);
+        assertThat(locator.locateBlobStore("id1", "two", null)
+                .getValue()).isSameAs(blobStoreOne);
+        assertThat(locator.locateBlobStore("id2", "cont5X.extra", null)
+                .getValue()).isSameAs(blobStoreTwo);
+    }
+}


### PR DESCRIPTION
558efb7b29e826aa introduced a bug where if anonymous access is
configured, the bucket locator hits a null pointer exception. There is
an additional bug where if an incorrect identity is used with the
blobstore locator (as in, the request identity does not match the
configured bucket's blobstore identity), another null pointer exception
can be triggered.

The patch creates a new GlobBlobStoreLocator class and adds tests to it,
as it is difficult to test Main.java directly. The blobstore locator
logic is also reworked to fix the above bugs.