### PR TITLE
Fix anonymous bucket listing bug

### DIFF
--- a/src/main/java/org/gaul/s3proxy/GlobBlobStoreLocator.java
+++ b/src/main/java/org/gaul/s3proxy/GlobBlobStoreLocator.java
@@ -41,17 +41,24 @@ public final class GlobBlobStoreLocator implements BlobStoreLocator {
         Map.Entry<String, BlobStore> locatorEntry =
                 locator.get(identity);
         Map.Entry<String, BlobStore> globEntry = null;
-        for (Map.Entry<PathMatcher, Map.Entry<String, BlobStore>>
-                entry : globLocator.entrySet()) {
-            if (entry.getKey().matches(FileSystems.getDefault()
-                    .getPath(container))) {
-                globEntry = entry.getValue();
+        if (container != null) {
+            for (Map.Entry<PathMatcher, Map.Entry<String, BlobStore>>
+                    entry : globLocator.entrySet()) {
+                if (entry.getKey().matches(FileSystems.getDefault()
+                        .getPath(container))) {
+                    globEntry = entry.getValue();
+                }
             }
         }
         if (globEntry == null) {
             if (identity == null) {
-                return locator.entrySet().iterator().next()
-                        .getValue();
+                if (!locator.isEmpty()) {
+                    return locator.entrySet().iterator().next()
+                            .getValue();
+                }
+                return Maps.immutableEntry(null,
+                        globLocator.entrySet().iterator().next().getValue()
+                                .getValue());
             }
             return locatorEntry;
         }

--- a/src/test/java/org/gaul/s3proxy/GlobBlobStoreLocatorTest.java
+++ b/src/test/java/org/gaul/s3proxy/GlobBlobStoreLocatorTest.java
@@ -128,4 +128,26 @@ public final class GlobBlobStoreLocatorTest {
         assertThat(locator.locateBlobStore("id2", "cont5X.extra", null)
                 .getValue()).isSameAs(blobStoreTwo);
     }
+
+    @Test
+    public void testGlobLocatorAnonymous() {
+        ImmutableMap<PathMatcher, Map.Entry<String, BlobStore>> globMap =
+                ImmutableMap.of(
+                        FileSystems.getDefault().getPathMatcher(
+                                "glob:one"),
+                        Maps.immutableEntry(null, blobStoreOne),
+                        FileSystems.getDefault().getPathMatcher(
+                                "glob:two"),
+                        Maps.immutableEntry(null, blobStoreTwo)
+                );
+        GlobBlobStoreLocator locator = new GlobBlobStoreLocator(
+                ImmutableMap.of(), globMap);
+
+        assertThat(locator.locateBlobStore(null, null, null)
+                .getValue()).isSameAs(blobStoreOne);
+        assertThat(locator.locateBlobStore(null, "one", null)
+                .getValue()).isSameAs(blobStoreOne);
+        assertThat(locator.locateBlobStore(null, "two", null)
+                .getValue()).isSameAs(blobStoreTwo);
+    }
 }


### PR DESCRIPTION
If the bucket locator is used with anonymous access, listing a container
results in a null-pointer exception, as there are no blobstores in the
locator. In that case, we should use the globLocator structure and
return the first available blobstore.