### PR TITLE
UT for #392

### DIFF
--- a/src/test/java/org/gaul/s3proxy/AwsSdkTest.java
+++ b/src/test/java/org/gaul/s3proxy/AwsSdkTest.java
@@ -1007,7 +1007,7 @@ public final class AwsSdkTest {
 
     @Test
     public void testSinglepartUploadJettyCachedHeader() throws Exception {
-        String blobName = "singlepart-upload";
+        String blobName = "singlepart-upload-jetty-cached";
         String contentType = "text/plain;charset=utf-8";
         byte[] data = "data".getBytes(StandardCharsets.UTF_8);
         ObjectMetadata metadata = new ObjectMetadata();


### PR DESCRIPTION
This UT reproduces issue #392:
attempts a plain simple putObject without
any "trickery", and fails with SignatureDoesNotMatch.

The trick is, to use such Content-Type header that
is cached by Jetty, as it seems all the UTs are using
content types that are not quite common, hance Jetty
cache is not pre-populated with those.