### PR TITLE
ci: Temurin JDK

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,7 +21,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
       - uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '11'
       - name: Install dependencies
         run: sudo apt-get install -y libevent-dev python3-pip python3-virtualenv


### PR DESCRIPTION
https://github.com/actions/setup-java/blob/main/README.md

```
NOTE: Adopt OpenJDK got moved to Eclipse Temurin and won't be updated anymore. 
It is highly recommended to migrate workflows from adopt to temurin 
to keep receiving software and security updates.
```
