### PR TITLE
NPE when creating a S3ProxyExtension with AuthenticationType.NONE

### DIFF
--- a/src/main/java/org/gaul/s3proxy/S3Proxy.java
+++ b/src/main/java/org/gaul/s3proxy/S3Proxy.java
@@ -316,8 +316,10 @@ public final class S3Proxy {
         public Builder awsAuthentication(AuthenticationType authenticationType,
                 String identity, String credential) {
             this.authenticationType = authenticationType;
-            this.identity = requireNonNull(identity);
-            this.credential = requireNonNull(credential);
+            if (!AuthenticationType.NONE.equals(authenticationType)) {
+                this.identity = requireNonNull(identity);
+                this.credential = requireNonNull(credential);
+            }
             return this;
         }
 

--- a/src/main/java/org/gaul/s3proxy/junit/S3ProxyJunitCore.java
+++ b/src/main/java/org/gaul/s3proxy/junit/S3ProxyJunitCore.java
@@ -112,10 +112,13 @@ public class S3ProxyJunitCore {
             throw new RuntimeException("Unable to initialize Blob Store", e);
         }
 
-        blobStoreContext = ContextBuilder.newBuilder(
+        ContextBuilder blobStoreContextBuilder = ContextBuilder.newBuilder(
                 builder.blobStoreProvider)
-                .credentials(accessKey, secretKey)
-                .overrides(properties).build(BlobStoreContext.class);
+                .overrides(properties);
+        if (!AuthenticationType.NONE.equals(builder.authType)) {
+            blobStoreContextBuilder = blobStoreContextBuilder.credentials(accessKey, secretKey);
+        }
+        blobStoreContext = blobStoreContextBuilder.build(BlobStoreContext.class);
 
         S3Proxy.Builder s3ProxyBuilder = S3Proxy.builder()
                 .blobStore(blobStoreContext.getBlobStore())

--- a/src/test/java/org/gaul/s3proxy/junit/S3ProxyExtensionTest.java
+++ b/src/test/java/org/gaul/s3proxy/junit/S3ProxyExtensionTest.java
@@ -93,4 +93,14 @@ public class S3ProxyExtensionTest {
         // Issue #299
         assertThat(s3Client.doesBucketExistV2("nonexistingbucket")).isFalse();
     }
+
+    @Test
+    public final void createExtentionWithoutCredentials() {
+        S3ProxyExtension extension = S3ProxyExtension
+                .builder()
+                .build();
+        assertThat(extension.getAccessKey()).isNull();
+        assertThat(extension.getSecretKey()).isNull();
+        assertThat(extension.getUri()).isNull();
+    }
 }

--- a/src/test/java/org/gaul/s3proxy/junit/S3ProxyRuleTest.java
+++ b/src/test/java/org/gaul/s3proxy/junit/S3ProxyRuleTest.java
@@ -95,4 +95,13 @@ public class S3ProxyRuleTest {
         assertThat(s3Client.doesBucketExistV2("nonexistingbucket")).isFalse();
     }
 
+    @Test
+    public final void createExtentionWithoutCredentials() {
+        S3ProxyRule extension = S3ProxyRule
+                .builder()
+                .build();
+        assertThat(extension.getAccessKey()).isNull();
+        assertThat(extension.getSecretKey()).isNull();
+        assertThat(extension.getUri()).isNull();
+    }
 }


### PR DESCRIPTION
closes #412 by fixing the NPE when creating a S3Proxy.

However, I'm not sure about how JCloud handles the NONE Authentication type since there is a nonNull check in there.
