### PR TITLE
Docker entrypoint: authentication for Azure Blob

### DIFF
--- a/src/main/resources/run-docker-container.sh
+++ b/src/main/resources/run-docker-container.sh
@@ -25,5 +25,8 @@ exec java \
     -Djclouds.keystone.scope="${JCLOUDS_KEYSTONE_SCOPE}" \
     -Djclouds.keystone.project-domain-name="${JCLOUDS_KEYSTONE_PROJECT_DOMAIN_NAME}" \
     -Djclouds.filesystem.basedir="${JCLOUDS_FILESYSTEM_BASEDIR}" \
+    -Djclouds.azureblob.tenantId="${JCLOUDS_AZUREBLOB_TENANTID}" \
+    -Djclouds.azureblob.auth="${JCLOUDS_AZUREBLOB_AUTH}" \
+    -Djclouds.azureblob.account="${JCLOUDS_AZUREBLOB_ACCOUNT}" \
     -jar /opt/s3proxy/s3proxy \
     --properties /dev/null


### PR DESCRIPTION
When using s3proxy as a proxy for S3 -> Azure Blob Storage, one needs to set the authentication parameters. When running in a container, these can be exposed via environment variables, but are currently not passed through to the jclouds config.

This is how we got it running for us in a custom build of the container.
Should I also add the options for other backends? Or do you see options for a generic solution?

Maybe also corresponds to #404