### PR TITLE
Upgrade to Jetty 11.0.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ and has instructions on how to run it.
 
 Users can [download releases](https://github.com/gaul/s3proxy/releases)
 from GitHub.  Developers can build the project by running `mvn package` which
-produces a binary at `target/s3proxy`.  S3Proxy requires Java 8 or newer to run.
+produces a binary at `target/s3proxy`.  S3Proxy requires Java 11 or newer to
+run.
 
 Configure S3Proxy via a properties file.  An example using the local
 file system as the storage backend with anonymous access:

--- a/pom.xml
+++ b/pom.xml
@@ -491,7 +491,7 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
-      <version>9.4.45.v20220203</version>
+      <version>11.0.11</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/src/main/java/org/gaul/s3proxy/AwsSignature.java
+++ b/src/main/java/org/gaul/s3proxy/AwsSignature.java
@@ -34,7 +34,6 @@ import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
-import javax.servlet.http.HttpServletRequest;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
@@ -45,6 +44,8 @@ import com.google.common.collect.TreeMultimap;
 import com.google.common.io.BaseEncoding;
 import com.google.common.net.HttpHeaders;
 import com.google.common.net.PercentEscaper;
+
+import jakarta.servlet.http.HttpServletRequest;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/org/gaul/s3proxy/S3ErrorCode.java
+++ b/src/main/java/org/gaul/s3proxy/S3ErrorCode.java
@@ -18,9 +18,9 @@ package org.gaul.s3proxy;
 
 import static java.util.Objects.requireNonNull;
 
-import javax.servlet.http.HttpServletResponse;
-
 import com.google.common.base.CaseFormat;
+
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * List of S3 error codes.  Reference:

--- a/src/main/java/org/gaul/s3proxy/S3Proxy.java
+++ b/src/main/java/org/gaul/s3proxy/S3Proxy.java
@@ -34,6 +34,7 @@ import com.google.common.collect.Lists;
 import org.eclipse.jetty.http.HttpCompliance;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.SecureRequestCustomizer;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.ContextHandler;
@@ -84,9 +85,13 @@ public final class S3Proxy {
             context.setContextPath(builder.servicePath);
         }
 
+        HttpConfiguration httpConfiguration = new HttpConfiguration();
+        httpConfiguration.setHttpCompliance(HttpCompliance.LEGACY);
+        SecureRequestCustomizer src = new SecureRequestCustomizer();
+        src.setSniHostCheck(false);
+        httpConfiguration.addCustomizer(src);
         HttpConnectionFactory httpConnectionFactory =
-                new HttpConnectionFactory(
-                        new HttpConfiguration(), HttpCompliance.LEGACY);
+                new HttpConnectionFactory(httpConfiguration);
         ServerConnector connector;
         if (builder.endpoint != null) {
             connector = new ServerConnector(server, httpConnectionFactory);
@@ -99,7 +104,7 @@ public final class S3Proxy {
         }
 
         if (builder.secureEndpoint != null) {
-            SslContextFactory sslContextFactory =
+            SslContextFactory.Server sslContextFactory =
                 new SslContextFactory.Server();
             sslContextFactory.setKeyStorePath(builder.keyStorePath);
             sslContextFactory.setKeyStorePassword(builder.keyStorePassword);

--- a/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
@@ -53,8 +53,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
@@ -81,6 +79,9 @@ import com.google.common.io.ByteStreams;
 import com.google.common.net.HostAndPort;
 import com.google.common.net.HttpHeaders;
 import com.google.common.net.PercentEscaper;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.apache.commons.fileupload.MultipartStream;
 import org.jclouds.blobstore.BlobStore;

--- a/src/main/java/org/gaul/s3proxy/S3ProxyHandlerJetty.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyHandlerJetty.java
@@ -21,10 +21,11 @@ import java.io.InputStream;
 import java.util.concurrent.TimeoutException;
 
 import javax.annotation.Nullable;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 import com.google.common.collect.ImmutableMap;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.AbstractHandler;

--- a/src/test/java/org/gaul/s3proxy/AwsSdkTest.java
+++ b/src/test/java/org/gaul/s3proxy/AwsSdkTest.java
@@ -1006,7 +1006,7 @@ public final class AwsSdkTest {
     @Test
     public void testSinglepartUploadJettyCachedHeader() throws Exception {
         String blobName = "singlepart-upload-jetty-cached";
-        String contentType = "text/plain;charset=utf-8";
+        String contentType = "text/plain";
         ObjectMetadata metadata = new ObjectMetadata();
         metadata.setContentLength(BYTE_SOURCE.size());
         metadata.setContentType(contentType);


### PR DESCRIPTION
Jetty 9 is EOL.  This requires Java 11 and updating some Java EE
imports.  Fixes #422.