### PR TITLE
Add S3PROXY_JAVA_OPTS environment variable

### DIFF
--- a/src/main/resources/run-docker-container.sh
+++ b/src/main/resources/run-docker-container.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 exec java \
+    $S3PROXY_JAVA_OPTS \
     -DLOG_LEVEL="${LOG_LEVEL}" \
     -Ds3proxy.endpoint="${S3PROXY_ENDPOINT}" \
     -Ds3proxy.virtual-host="${S3PROXY_VIRTUALHOST}" \


### PR DESCRIPTION
Add a `S3PROXY_JAVA_OPTS` environment variable into the run-docker-container.sh file. This will allow users to easily pass in custom options to the JVM. 

For example, my use case is to pass `-Xmx` and `-Xms` which can be passed using this variable