### PR TITLE
Add missing environment variable for secure endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,5 +36,5 @@ ENV \
     JCLOUDS_KEYSTONE_PROJECT_DOMAIN_NAME="" \
     JCLOUDS_FILESYSTEM_BASEDIR="/data"
 
-EXPOSE 80
+EXPOSE 80 443
 ENTRYPOINT ["/opt/s3proxy/run-docker-container.sh"]

--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ S3Proxy can modify its behavior based on middlewares:
 * [read-only](https://github.com/gaul/s3proxy/wiki/Middleware-read-only)
 * [sharded backend containers](https://github.com/gaul/s3proxy/wiki/Middleware-sharded-backend)
 
+## TLS Support
+
+S3Proxy can listen on HTTPS by setting the `secure-endpoint` and [configuring a keystore](http://wiki.eclipse.org/Jetty/Howto/Configure_SSL#Generating_Keys_and_Certificates_with_JDK_keytool). You can read more about how configure S3Proxy for TLS Support in [the dedicated wiki page](https://github.com/gaul/s3proxy/wiki/SSL-support) with Docker, Kubernetes or simply Java.
+
 ## Limitations
 
 S3Proxy has broad compatibility with the S3 API, however, it does not support:

--- a/README.md
+++ b/README.md
@@ -108,9 +108,9 @@ S3Proxy can modify its behavior based on middlewares:
 * [read-only](https://github.com/gaul/s3proxy/wiki/Middleware-read-only)
 * [sharded backend containers](https://github.com/gaul/s3proxy/wiki/Middleware-sharded-backend)
 
-## TLS Support
+## SSL Support
 
-S3Proxy can listen on HTTPS by setting the `secure-endpoint` and [configuring a keystore](http://wiki.eclipse.org/Jetty/Howto/Configure_SSL#Generating_Keys_and_Certificates_with_JDK_keytool). You can read more about how configure S3Proxy for TLS Support in [the dedicated wiki page](https://github.com/gaul/s3proxy/wiki/SSL-support) with Docker, Kubernetes or simply Java.
+S3Proxy can listen on HTTPS by setting the `secure-endpoint` and [configuring a keystore](http://wiki.eclipse.org/Jetty/Howto/Configure_SSL#Generating_Keys_and_Certificates_with_JDK_keytool). You can read more about how configure S3Proxy for SSL Support in [the dedicated wiki page](https://github.com/gaul/s3proxy/wiki/SSL-support) with Docker, Kubernetes or simply Java.
 
 ## Limitations
 

--- a/src/main/resources/run-docker-container.sh
+++ b/src/main/resources/run-docker-container.sh
@@ -19,7 +19,7 @@ exec java \
     -Ds3proxy.encrypted-blobstore="${S3PROXY_ENCRYPTED_BLOBSTORE}" \
     -Ds3proxy.encrypted-blobstore-password="${S3PROXY_ENCRYPTED_BLOBSTORE_PASSWORD}" \
     -Ds3proxy.encrypted-blobstore-salt="${S3PROXY_ENCRYPTED_BLOBSTORE_SALT}" \
-    -Ds3proxy.v4-max-non-chunked-request-size="${S3PROXY_V4_MAX_NON_CHUNKED_REQ_SIZE}" \
+    -Ds3proxy.v4-max-non-chunked-request-size="${S3PROXY_V4_MAX_NON_CHUNKED_REQ_SIZE:-33554432}" \
     -Djclouds.provider="${JCLOUDS_PROVIDER}" \
     -Djclouds.identity="${JCLOUDS_IDENTITY}" \
     -Djclouds.credential="${JCLOUDS_CREDENTIAL}" \

--- a/src/main/resources/run-docker-container.sh
+++ b/src/main/resources/run-docker-container.sh
@@ -4,6 +4,7 @@ exec java \
     $S3PROXY_JAVA_OPTS \
     -DLOG_LEVEL="${LOG_LEVEL}" \
     -Ds3proxy.endpoint="${S3PROXY_ENDPOINT}" \
+    -Ds3proxy.secure-endpoint="${S3PROXY_SECURE_ENDPOINT}" \
     -Ds3proxy.virtual-host="${S3PROXY_VIRTUALHOST}" \
     -Ds3proxy.keystore-path="${S3PROXY_KEYSTORE_PATH}" \
     -Ds3proxy.keystore-password="${S3PROXY_KEYSTORE_PASSWORD}" \


### PR DESCRIPTION
Following #512, we need to add support for the "secure endpoint" parameter through environment variables. I also added a default value for the chunked request size (found in the java code source) since an empty value will raise an exception:

```
[s3proxy] E 04-20 10:16:36.854 main org.gaul.s3proxy.Main:279 |::] java.lang.NumberFormatException: For input string: ""
[s3proxy] E 04-20 10:16:36.855 main org.gaul.s3proxy.Main:279 |::]     at java.base/java.lang.NumberFormatException.forInputSt
[s3proxy] E 04-20 10:16:36.855 main org.gaul.s3proxy.Main:279 |::]     at java.base/java.lang.Long.parseLong(Unknown Source)
[s3proxy] E 04-20 10:16:36.855 main org.gaul.s3proxy.Main:279 |::]     at java.base/java.lang.Long.parseLong(Unknown Source)
[s3proxy] E 04-20 10:16:36.856 main org.gaul.s3proxy.Main:279 |::]     at org.gaul.s3proxy.S3Proxy$Builder.fromProperties(S3Pr
[s3proxy] E 04-20 10:16:36.856 main org.gaul.s3proxy.Main:279 |::]     at org.gaul.s3proxy.Main.main(Main.java:158)
```