### PR TITLE
fixed marker being saved under wrong key in marker cache

### DIFF
--- a/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
@@ -1491,7 +1491,7 @@ public class S3ProxyHandler {
                     StorageMetadata sm = Streams.findLast(set.stream()).orElse(null);
                     if (sm != null) {
                         lastKeyToMarker.put(Maps.immutableEntry(containerName,
-                                sm.getName()), nextMarker);
+                                encodeBlob(encodingType, nextMarker)), nextMarker);
                     }
                 }
             } else {


### PR DESCRIPTION
Currently pagination is broken for backends that use opaque markers. It is so because the key (`last key from the set`) under which a real marker is saved is different than the key (`encoded marker`) that S3Proxy is trying to use to read a real marker.

It results with S3Proxy being able to fetch only 1 page:

```
2023-07-04 14:02:31         13 hw
2023-07-04 14:37:11         13 hw-a-0
2023-07-04 14:43:21         13 hw-aa-0
2023-07-04 14:43:22         13 hw-aa-1
2023-07-04 14:43:29         13 hw-aa-10
2023-07-04 14:43:59         13 hw-aa-100
2023-07-04 14:48:29         13 hw-aa-1000
2023-07-04 14:48:30         13 hw-aa-1001
2023-07-04 14:48:30         13 hw-aa-1002
2023-07-04 14:48:30         13 hw-aa-1003

An error occurred (BadDigest) when calling the ListObjectsV2 operation (reached max retries: 4): Bad Request
```

This could be solved by either using `last key from the set` as a marker in response or using `encoded nextMarker` as part of key in cache. In this PR I decided to implement the second solution.