### PR TITLE
explicitly depend on plexus-utils in modernizer plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -343,6 +343,13 @@
         <configuration>
           <javaVersion>${java.version}</javaVersion>
         </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+            <version>4.0.0</version>
+          </dependency>
+        </dependencies>
       </plugin>
       <plugin>
         <groupId>org.sonatype.plugins</groupId>


### PR DESCRIPTION
The implicit dependency on plexus-utils was dropped in maven 3.9.0, so this fix is needed to build on newer versions of maven.