### PR TITLE
update modernizer plugin to 2.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -330,7 +330,7 @@
       <plugin>
         <groupId>org.gaul</groupId>
         <artifactId>modernizer-maven-plugin</artifactId>
-        <version>2.5.0</version>
+        <version>2.6.0</version>
         <executions>
           <execution>
             <id>modernizer</id>

--- a/pom.xml
+++ b/pom.xml
@@ -330,7 +330,7 @@
       <plugin>
         <groupId>org.gaul</groupId>
         <artifactId>modernizer-maven-plugin</artifactId>
-        <version>2.4.0</version>
+        <version>2.5.0</version>
         <executions>
           <execution>
             <id>modernizer</id>


### PR DESCRIPTION
This allows the project to work with maven 3.9+, as the modernizer no longer implicitly depends on plexus-utils.