### PR TITLE
upgrade OS packages in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,12 @@
 FROM openjdk:11-jre-slim
 LABEL maintainer="Andrew Gaul <andrew@gaul.org>"
 
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 WORKDIR /opt/s3proxy
 
 COPY \


### PR DESCRIPTION
This reduces the number of vulnerabilities in the final image

Before (reported by trivy)
Total: 141 (UNKNOWN: 0, LOW: 68, MEDIUM: 32, HIGH: 36, CRITICAL: 5)
After (reported by trivy)
Total: 89 (UNKNOWN: 0, LOW: 68, MEDIUM: 10, HIGH: 10, CRITICAL: 1)