### PR TITLE
change base image to eclipse-temurin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jre-slim
+FROM eclipse-temurin:11-jre
 LABEL maintainer="Andrew Gaul <andrew@gaul.org>"
 
 WORKDIR /opt/s3proxy


### PR DESCRIPTION
The openjdk images are deprecated, and have critical vulnerabilities