### PR TITLE
Add DELETE and HEAD methods for CORS and CORS headers for all responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ s3proxy.cors-allow-credential=true
 ```
 
 CORS cannot be configured per bucket. `s3proxy.cors-allow-all=true` will accept any origin and header.
-Actual CORS requests are supported for GET, PUT and POST methods.
+Actual CORS requests are supported for GET, PUT, POST, HEAD and DELETE methods.
 
 The wiki collects
 [compatibility notes](https://github.com/gaul/s3proxy/wiki/Storage-backend-compatibility)

--- a/src/main/java/org/gaul/s3proxy/CrossOriginResourceSharing.java
+++ b/src/main/java/org/gaul/s3proxy/CrossOriginResourceSharing.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
 
 public final class CrossOriginResourceSharing {
     protected static final Collection<String> SUPPORTED_METHODS =
-            ImmutableList.of("GET", "HEAD", "PUT", "POST");
+            ImmutableList.of("GET", "HEAD", "PUT", "POST", "DELETE");
 
     private static final String HEADER_VALUE_SEPARATOR = ", ";
     private static final String ALLOW_ANY_ORIGIN = "*";

--- a/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
@@ -848,15 +848,6 @@ public class S3ProxyHandler {
                 throw new S3Exception(S3ErrorCode.ACCESS_DENIED);
             } else {
                 String containerName = path[1];
-                /*
-                 * Only check access on bucket level. The preflight request
-                 * might be for a PUT, so the object is not yet there.
-                 */
-                ContainerAccess access = blobStore.getContainerAccess(
-                        containerName);
-                if (access == ContainerAccess.PRIVATE) {
-                    throw new S3Exception(S3ErrorCode.ACCESS_DENIED);
-                }
                 handleOptionsBlob(request, response, blobStore, containerName);
                 return;
             }

--- a/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
@@ -877,6 +877,7 @@ public class S3ProxyHandler {
         ContainerAccess access = blobStore.getContainerAccess(containerName);
 
         response.setCharacterEncoding(UTF_8);
+        addCorsResponseHeader(request, response);
         try (Writer writer = response.getWriter()) {
             response.setContentType(XML_CONTENT_TYPE);
             XMLStreamWriter xml = xmlOutputFactory.createXMLStreamWriter(
@@ -931,7 +932,6 @@ public class S3ProxyHandler {
         } catch (XMLStreamException xse) {
             throw new IOException(xse);
         }
-        addCorsResponseHeader(request, response);
     }
 
     private void handleSetContainerAcl(HttpServletRequest request,
@@ -977,6 +977,7 @@ public class S3ProxyHandler {
         BlobAccess access = blobStore.getBlobAccess(containerName, blobName);
 
         response.setCharacterEncoding(UTF_8);
+        addCorsResponseHeader(request, response);
         try (Writer writer = response.getWriter()) {
             response.setContentType(XML_CONTENT_TYPE);
             XMLStreamWriter xml = xmlOutputFactory.createXMLStreamWriter(
@@ -1031,7 +1032,6 @@ public class S3ProxyHandler {
         } catch (XMLStreamException xse) {
             throw new IOException(xse);
         }
-        addCorsResponseHeader(request, response);
     }
 
     private void handleSetBlobAcl(HttpServletRequest request,
@@ -1114,6 +1114,7 @@ public class S3ProxyHandler {
         PageSet<? extends StorageMetadata> buckets = blobStore.list();
 
         response.setCharacterEncoding(UTF_8);
+        addCorsResponseHeader(request, response);
         try (Writer writer = response.getWriter()) {
             response.setContentType(XML_CONTENT_TYPE);
             XMLStreamWriter xml = xmlOutputFactory.createXMLStreamWriter(
@@ -1150,12 +1151,12 @@ public class S3ProxyHandler {
         } catch (XMLStreamException xse) {
             throw new IOException(xse);
         }
-        addCorsResponseHeader(request, response);
     }
 
     private void handleContainerLocation(HttpServletRequest request,
             HttpServletResponse response) throws IOException {
         response.setCharacterEncoding(UTF_8);
+        addCorsResponseHeader(request, response);
         try (Writer writer = response.getWriter()) {
             response.setContentType(XML_CONTENT_TYPE);
             XMLStreamWriter xml = xmlOutputFactory.createXMLStreamWriter(
@@ -1169,7 +1170,6 @@ public class S3ProxyHandler {
         } catch (XMLStreamException xse) {
             throw new IOException(xse);
         }
-        addCorsResponseHeader(request, response);
     }
 
     private static void handleBucketPolicy(BlobStore blobStore,
@@ -1197,6 +1197,7 @@ public class S3ProxyHandler {
                 container);
 
         response.setCharacterEncoding(UTF_8);
+        addCorsResponseHeader(request, response);
         try (Writer writer = response.getWriter()) {
             response.setContentType(XML_CONTENT_TYPE);
             XMLStreamWriter xml = xmlOutputFactory.createXMLStreamWriter(
@@ -1255,7 +1256,6 @@ public class S3ProxyHandler {
         } catch (XMLStreamException xse) {
             throw new IOException(xse);
         }
-        addCorsResponseHeader(request, response);
     }
 
     private void handleContainerExists(HttpServletRequest request,
@@ -1593,6 +1593,7 @@ public class S3ProxyHandler {
         blobStore.removeBlobs(containerName, blobNames);
 
         response.setCharacterEncoding(UTF_8);
+        addCorsResponseHeader(request, response);
         try (Writer writer = response.getWriter()) {
             response.setContentType(XML_CONTENT_TYPE);
             XMLStreamWriter xml = xmlOutputFactory.createXMLStreamWriter(
@@ -1617,7 +1618,6 @@ public class S3ProxyHandler {
         } catch (XMLStreamException xse) {
             throw new IOException(xse);
         }
-        addCorsResponseHeader(request, response);
     }
 
     private void handleBlobMetadata(HttpServletRequest request,
@@ -1887,6 +1887,7 @@ public class S3ProxyHandler {
         BlobMetadata blobMetadata = blobStore.blobMetadata(destContainerName,
                 destBlobName);
         response.setCharacterEncoding(UTF_8);
+        addCorsResponseHeader(request, response);
         try (Writer writer = response.getWriter()) {
             response.setContentType(XML_CONTENT_TYPE);
             XMLStreamWriter xml = xmlOutputFactory.createXMLStreamWriter(
@@ -1904,7 +1905,6 @@ public class S3ProxyHandler {
         } catch (XMLStreamException xse) {
             throw new IOException(xse);
         }
-        addCorsResponseHeader(request, response);
     }
 
     private void handlePutBlob(HttpServletRequest request,
@@ -2217,6 +2217,7 @@ public class S3ProxyHandler {
         }
 
         response.setCharacterEncoding(UTF_8);
+        addCorsResponseHeader(request, response);
         try (Writer writer = response.getWriter()) {
             response.setContentType(XML_CONTENT_TYPE);
             XMLStreamWriter xml = xmlOutputFactory.createXMLStreamWriter(
@@ -2234,8 +2235,6 @@ public class S3ProxyHandler {
         } catch (XMLStreamException xse) {
             throw new IOException(xse);
         }
-
-        addCorsResponseHeader(request, response);
     }
 
     private void handleCompleteMultipartUpload(HttpServletRequest request,
@@ -2342,6 +2341,7 @@ public class S3ProxyHandler {
         }
 
         response.setCharacterEncoding(UTF_8);
+        addCorsResponseHeader(request, response);
         try (PrintWriter writer = response.getWriter()) {
             response.setStatus(HttpServletResponse.SC_OK);
             response.setContentType(XML_CONTENT_TYPE);
@@ -2405,8 +2405,6 @@ public class S3ProxyHandler {
         } catch (XMLStreamException xse) {
             throw new IOException(xse);
         }
-
-        addCorsResponseHeader(request, response);
     }
 
     private void handleAbortMultipartUpload(HttpServletRequest request,
@@ -2472,6 +2470,7 @@ public class S3ProxyHandler {
         String encodingType = request.getParameter("encoding-type");
 
         response.setCharacterEncoding(UTF_8);
+        addCorsResponseHeader(request, response);
         try (Writer writer = response.getWriter()) {
             response.setContentType(XML_CONTENT_TYPE);
             XMLStreamWriter xml = xmlOutputFactory.createXMLStreamWriter(
@@ -2529,8 +2528,6 @@ public class S3ProxyHandler {
         } catch (XMLStreamException xse) {
             throw new IOException(xse);
         }
-
-        addCorsResponseHeader(request, response);
     }
 
     private void handleCopyPart(HttpServletRequest request,
@@ -2706,6 +2703,7 @@ public class S3ProxyHandler {
         }
 
         response.setCharacterEncoding(UTF_8);
+        addCorsResponseHeader(request, response);
         try (Writer writer = response.getWriter()) {
             response.setContentType(XML_CONTENT_TYPE);
             XMLStreamWriter xml = xmlOutputFactory.createXMLStreamWriter(
@@ -2724,8 +2722,6 @@ public class S3ProxyHandler {
         } catch (XMLStreamException xse) {
             throw new IOException(xse);
         }
-
-        addCorsResponseHeader(request, response);
     }
 
     private void handleUploadPart(HttpServletRequest request,

--- a/src/test/java/org/gaul/s3proxy/CrossOriginResourceSharingAllowAllResponseTest.java
+++ b/src/test/java/org/gaul/s3proxy/CrossOriginResourceSharingAllowAllResponseTest.java
@@ -157,7 +157,7 @@ public final class CrossOriginResourceSharingAllowAllResponseTest {
                 HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS)).isTrue();
         assertThat(response.getFirstHeader(
                 HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS).getValue())
-                .isEqualTo("GET, HEAD, PUT, POST");
+                .isEqualTo("GET, HEAD, PUT, POST, DELETE");
         assertThat(response.containsHeader(
                 HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS)).isTrue();
         assertThat(response.getFirstHeader(
@@ -181,7 +181,7 @@ public final class CrossOriginResourceSharingAllowAllResponseTest {
                 HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS)).isTrue();
         assertThat(response.getFirstHeader(
                 HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS).getValue())
-                    .isEqualTo("GET, HEAD, PUT, POST");
+                    .isEqualTo("GET, HEAD, PUT, POST, DELETE");
     }
 
     @Test

--- a/src/test/java/org/gaul/s3proxy/CrossOriginResourceSharingRuleTest.java
+++ b/src/test/java/org/gaul/s3proxy/CrossOriginResourceSharingRuleTest.java
@@ -107,6 +107,12 @@ public final class CrossOriginResourceSharingRuleTest {
         probe = "POST";
         assertThat(corsAll.isMethodAllowed(probe))
                 .as("check '%s' as method", probe).isTrue();
+        probe = "HEAD";
+        assertThat(corsAll.isMethodAllowed(probe))
+                .as("check '%s' as method", probe).isTrue();
+        probe = "DELETE";
+        assertThat(corsAll.isMethodAllowed(probe))
+                .as("check '%s' as method", probe).isTrue();
     }
 
     @Test


### PR DESCRIPTION
1. I found that DELETE method is not supported for CORS, which should be included. Refer to: [aws CORS config](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ManageCorsUsing.html#cors-allowed-methods)

2. Currently, not all handle methods include "addCorsResponseHeader". I add it in all handle methods, because in most cases, the browser needs it.