### PR TITLE
Restore OPAQUE_MARKERS handling for list objects V1

### DIFF
--- a/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
@@ -1490,8 +1490,12 @@ public class S3ProxyHandler {
                 if (Quirks.OPAQUE_MARKERS.contains(blobStoreType)) {
                     StorageMetadata sm = Streams.findLast(set.stream()).orElse(null);
                     if (sm != null) {
-                        lastKeyToMarker.put(Maps.immutableEntry(containerName,
-                                encodeBlob(encodingType, nextMarker)), nextMarker);
+                        // TODO: verify if we need this handling at all for V2
+                        String lastKey = isListV2 ? encodeBlob(encodingType, nextMarker) : sm.getName();
+                        lastKeyToMarker.put(
+                                Maps.immutableEntry(containerName, lastKey),
+                                nextMarker
+                        );
                     }
                 }
             } else {


### PR DESCRIPTION
We need this to support V1 clients that use the last object name in the response as a marker for the next page (which is allowed according to the S3 docs).