### PR TITLE
fix pushing images to docker.io

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -6,34 +6,33 @@ on:
   pull_request:
     branches:
       - "*"
+
+env:
+  dockerhub_publish: ${{ secrets.DOCKER_PASS != '' }}
+
 jobs:
+  
   meta:
     runs-on: ubuntu-latest
     outputs:
-      dockerhub-publish: ${{ steps.dockerhub-publish.outputs.defined }}
-      registry: ghcr.io/${{ github.repository }}/container:${{ fromJSON(steps.docker_action_meta.outputs.json).labels['org.opencontainers.image.version'] }}
       container_tags: ${{ steps.docker_action_meta.outputs.tags }}
       container_labels: ${{ steps.docker_action_meta.outputs.labels }}
       container_buildtime: ${{ fromJSON(steps.docker_action_meta.outputs.json).labels['org.opencontainers.image.created'] }}
       container_version: ${{ fromJSON(steps.docker_action_meta.outputs.json).labels['org.opencontainers.image.version'] }}
       container_revision: ${{ fromJSON(steps.docker_action_meta.outputs.json).labels['org.opencontainers.image.revision'] }}
-      container_base: ${{ fromJSON(steps.docker_action_meta.outputs.json).tags[0] }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
           submodules: false
           persist-credentials: false
-      - id: dockerhub-publish
-        if: "${{ env.MY_KEY != '' }}"
-        run: echo "::set-output name=defined::true"
-        env:
-          MY_KEY: ${{ secrets.DOCKER_PASS }}
       - name: Docker meta
         id: docker_action_meta
         uses: docker/metadata-action@v4.0.1
         with:
-          images: ghcr.io/${{ github.repository }}/container
+          images:
+            name=ghcr.io/${{ github.repository }}/container
+            name=andrewgaul/s3proxy,enable=${{ env.dockerhub_publish }}
           flavor: |
             latest=false
           tags: |
@@ -103,17 +102,17 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2.0.0
-        if: github.event_name != 'pull_request' && needs.meta.outputs.dockerhub-publish == 'true'
+        uses: docker/login-action@v3
+        if: github.event_name != 'pull_request' && env.dockerhub_publish == 'true'
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASS }}
 
       - name: Login to GHCR
-        uses: docker/login-action@v2.0.0
+        uses: docker/login-action@v3
         if: github.event_name != 'pull_request'
         with:
           registry: ghcr.io
@@ -121,26 +120,14 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: .
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ needs.meta.outputs.container_base }}
+          tags: ${{ needs.meta.outputs.container_tags }}
           labels: ${{ needs.meta.outputs.container_labels }}
           build-args: |
             BUILDTIME=${{ needs.meta.outputs.container_buildtime }}
             VERSION=${{ needs.meta.outputs.container_version }}
             REVISION=${{ needs.meta.outputs.container_revision }}
-          cache-from: type=registry,ref=${{ needs.meta.outputs.container_base }}
-          cache-to: type=inline
-
-      - name: Publish to Docker
-        if: github.event_name != 'pull_request' && needs.meta.outputs.dockerhub-publish == 'true'
-        run: |
-          curl -L https://github.com/regclient/regclient/releases/download/v0.3.5/regctl-linux-amd64 >/tmp/regctl
-          chmod 755 /tmp/regctl
-          for line in $CONTAINER_DEST_TAGS; do echo working on "$line"; /tmp/regctl image copy $SOURCE_CONTAINER $line; done
-        env:
-          SOURCE_CONTAINER: ${{ needs.meta.outputs.container_version }}
-          CONTAINER_DEST_TAGS: ${{ needs.meta.outputs.container_tags }}

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -131,3 +131,5 @@ jobs:
             BUILDTIME=${{ needs.meta.outputs.container_buildtime }}
             VERSION=${{ needs.meta.outputs.container_version }}
             REVISION=${{ needs.meta.outputs.container_revision }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Hi @gaul.

I took me a lot of time, reading and trial and error but I've finally come up with something to fix #479 and prepare for issue #591 I created myself yesterday.

I never used Github Actions myself so I googled a bit and found out that the [official action](https://docs.docker.com/build/ci/github-actions/push-multi-registries/) that is used to push to ghcr.io can also be used to push to docker.io without relying on regctl.

To do this one needs to pass [multiple image names](https://docs.docker.com/build/ci/github-actions/manage-tags-labels/) that are the base for building the targets to push to.

According to how the tags in the meta action are currently setup these changes resulted in 3 tags getting pushed to both ghcr.io and docker.io each time I pushed to my branch. (docker.io depending on the existence of the DOCKER_PASS secret as before)

## docker.io

![docker.io](https://github.com/gaul/s3proxy/assets/30478030/05918c61-1c99-4f9c-a7d7-0a06e59485a7)

## ghrc.io
![ghrc.io](https://github.com/gaul/s3proxy/assets/30478030/be335038-f4b2-4ecf-b3f0-9197e84bfe24)

I also put the variable that checks for presence of the secret on the top level as it made it more readable and use some never action versions in a few places. And configured caching via [github actions](https://docs.docker.com/build/cache/backends/gha/#using-dockerbuild-push-action). This cache type is still experimental but the recommended one.

I'm not contributing a lot so if I miss something that is expected please let me know.