### PR TITLE
add missing pipe-character for images in meta step

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -30,7 +30,7 @@ jobs:
         id: docker_action_meta
         uses: docker/metadata-action@v4.0.1
         with:
-          images:
+          images: |
             name=ghcr.io/${{ github.repository }}/container
             name=andrewgaul/s3proxy,enable=${{ env.dockerhub_publish }}
           flavor: |


### PR DESCRIPTION
Hi @gaul.

As promised I had another look and I missed the pipe character in the images-definition which leads to ignored newlines which then produce the wrong outputs in the meta step.
(I tested locally in a private repo and copied my changes to the fork afterwards, i must have missed this one)

Wrong version from the failed [action log](https://github.com/gaul/s3proxy/actions/runs/7485958402/job/20375361868#step:3:29) including "name" from line 35 before `,enable=true`:
```
Processing images input
  name=ghcr.io/gaul/s3proxy/container name,enable=true
```

How it should look
```
Processing images input
  name=ghcr.io/gaul/s3proxy/container,enable=true
```

The automatic build triggered through this PR looks [correct this time](https://github.com/gaul/s3proxy/actions/runs/7491610177/job/20393212126?pr=595#step:3:32), feel free to mention me if it doesn't.

Not quite sure yet, but chances are high I will try to fix those warnings too - they bother me somehow. :)