### PR TITLE
create docker images for armv7

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -123,7 +123,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ needs.meta.outputs.container_tags }}
           labels: ${{ needs.meta.outputs.container_labels }}


### PR DESCRIPTION
When by #595 pushing images to dockerhub is working again, this fixes #591 and creates an additional docker image for architecture linux/arm/v7.