### PR TITLE
Configure maximum-timeskew with environment variable

### DIFF
--- a/src/main/java/org/gaul/s3proxy/S3Proxy.java
+++ b/src/main/java/org/gaul/s3proxy/S3Proxy.java
@@ -303,7 +303,7 @@ public final class S3Proxy {
 
             String maximumTimeSkew = properties.getProperty(
                     S3ProxyConstants.PROPERTY_MAXIMUM_TIME_SKEW);
-            if (maximumTimeSkew != null) {
+            if (maximumTimeSkew != null && !maximumTimeSkew.trim().isEmpty()) {
                 builder.maximumTimeSkew(Integer.parseInt(maximumTimeSkew));
             }
 

--- a/src/main/resources/run-docker-container.sh
+++ b/src/main/resources/run-docker-container.sh
@@ -22,6 +22,7 @@ exec java \
     -Ds3proxy.encrypted-blobstore-salt="${S3PROXY_ENCRYPTED_BLOBSTORE_SALT}" \
     -Ds3proxy.v4-max-non-chunked-request-size="${S3PROXY_V4_MAX_NON_CHUNKED_REQ_SIZE:-33554432}" \
     -Ds3proxy.read-only-blobstore="${S3PROXY_READ_ONLY_BLOBSTORE:-false}" \
+    -Ds3proxy.maximum-timeskew="${S3PROXY_MAXIMUM_TIMESKEW}" \
     -Djclouds.provider="${JCLOUDS_PROVIDER}" \
     -Djclouds.identity="${JCLOUDS_IDENTITY}" \
     -Djclouds.credential="${JCLOUDS_CREDENTIAL}" \


### PR DESCRIPTION
Adding the ability to configure s3proxy.maximum-timeskew using an environment variable.