### PR TITLE
Adds ETag to Access-Control-Expose-Headers headers

### DIFF
--- a/src/main/java/org/gaul/s3proxy/CrossOriginResourceSharing.java
+++ b/src/main/java/org/gaul/s3proxy/CrossOriginResourceSharing.java
@@ -41,6 +41,7 @@ public final class CrossOriginResourceSharing {
     private static final String ALLOW_ANY_ORIGIN = "*";
     private static final String ALLOW_ANY_HEADER = "*";
     private static final String ALLOW_CREDENTIALS = "true";
+    private static final String EXPOSED_HEADERS = "ETag";
 
     private static final Logger logger = LoggerFactory.getLogger(
             CrossOriginResourceSharing.class);
@@ -101,6 +102,10 @@ public final class CrossOriginResourceSharing {
         logger.info("CORS allowed methods: {}", allowedMethods);
         logger.info("CORS allowed headers: {}", allowedHeaders);
         logger.info("CORS allow credentials: {}", allowCredentials);
+    }
+    
+    public String getExposedHeaders() {
+        return EXPOSED_HEADERS;
     }
 
     public String getAllowedMethods() {

--- a/src/main/java/org/gaul/s3proxy/CrossOriginResourceSharing.java
+++ b/src/main/java/org/gaul/s3proxy/CrossOriginResourceSharing.java
@@ -103,7 +103,7 @@ public final class CrossOriginResourceSharing {
         logger.info("CORS allowed headers: {}", allowedHeaders);
         logger.info("CORS allow credentials: {}", allowCredentials);
     }
-    
+
     public String getExposedHeaders() {
         return EXPOSED_HEADERS;
     }

--- a/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
@@ -3012,7 +3012,7 @@ public class S3ProxyHandler {
                 corsRules.isOriginAllowed(corsOrigin)) {
             response.addHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN,
                     corsRules.getAllowedOrigin(corsOrigin));
-            response.addHeader(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS, 
+            response.addHeader(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS,
                     corsRules.getExposedHeaders());
             response.addHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS,
                     corsRules.getAllowedMethods());

--- a/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
@@ -3012,6 +3012,8 @@ public class S3ProxyHandler {
                 corsRules.isOriginAllowed(corsOrigin)) {
             response.addHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN,
                     corsRules.getAllowedOrigin(corsOrigin));
+            response.addHeader(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS, 
+                corsRules.getExposedHeaders());
             response.addHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS,
                     corsRules.getAllowedMethods());
             if (corsRules.isAllowCredentials()) {

--- a/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
@@ -3013,7 +3013,7 @@ public class S3ProxyHandler {
             response.addHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN,
                     corsRules.getAllowedOrigin(corsOrigin));
             response.addHeader(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS, 
-                corsRules.getExposedHeaders());
+                    corsRules.getExposedHeaders());
             response.addHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS,
                     corsRules.getAllowedMethods());
             if (corsRules.isAllowCredentials()) {

--- a/src/test/java/org/gaul/s3proxy/CrossOriginResourceSharingAllowAllResponseTest.java
+++ b/src/test/java/org/gaul/s3proxy/CrossOriginResourceSharingAllowAllResponseTest.java
@@ -181,7 +181,7 @@ public final class CrossOriginResourceSharingAllowAllResponseTest {
                     .isEqualTo("GET, HEAD, PUT, POST, DELETE");
         assertThat(response.getFirstHeader(
                 HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS).getValue())
-                .isEqualTo("ETag");
+                    .isEqualTo("ETag");
     }
 
     @Test

--- a/src/test/java/org/gaul/s3proxy/CrossOriginResourceSharingAllowAllResponseTest.java
+++ b/src/test/java/org/gaul/s3proxy/CrossOriginResourceSharingAllowAllResponseTest.java
@@ -179,6 +179,9 @@ public final class CrossOriginResourceSharingAllowAllResponseTest {
         assertThat(response.getFirstHeader(
                 HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS).getValue())
                     .isEqualTo("GET, HEAD, PUT, POST, DELETE");
+        assertThat(response.getFirstHeader(
+                HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS).getValue())
+                .isEqualTo("ETag");
     }
 
     @Test


### PR DESCRIPTION
I mentioned this in issue https://github.com/gaul/s3proxy/issues/667 but suffice to say that, while `ETag` is available as a header from many of the APIs in S3Proxy, the browser cannot access it since it's missing from the `Access-Control-Expose-Headers` list. To allow accessing this header from the browser, it needs to be added to the [Access-Control-Expose-Headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers) header.