### PR TITLE
Adds feature allowing Access-Control-Expose-Headers configuration

### DIFF
--- a/src/main/java/org/gaul/s3proxy/CrossOriginResourceSharing.java
+++ b/src/main/java/org/gaul/s3proxy/CrossOriginResourceSharing.java
@@ -40,6 +40,7 @@ public final class CrossOriginResourceSharing {
     private static final String HEADER_VALUE_SEPARATOR = ", ";
     private static final String ALLOW_ANY_ORIGIN = "*";
     private static final String ALLOW_ANY_HEADER = "*";
+    private static final String EXPOSE_ALL_HEADERS = "*";
     private static final String ALLOW_CREDENTIALS = "true";
 
     private static final Logger logger = LoggerFactory.getLogger(
@@ -47,21 +48,25 @@ public final class CrossOriginResourceSharing {
 
     private final String allowedMethodsRaw;
     private final String allowedHeadersRaw;
+    private final String exposedHeadersRaw;
     private final boolean anyOriginAllowed;
     private final Set<Pattern> allowedOrigins;
     private final Set<String> allowedMethods;
     private final Set<String> allowedHeaders;
+    private final Set<String> exposedHeaders;
     private final String allowCredentials;
 
     public CrossOriginResourceSharing() {
         // CORS Allow all
         this(Lists.newArrayList(ALLOW_ANY_ORIGIN), SUPPORTED_METHODS,
-                Lists.newArrayList(ALLOW_ANY_HEADER), "");
+            Lists.newArrayList(ALLOW_ANY_HEADER),
+            Lists.newArrayList(EXPOSE_ALL_HEADERS), "");
     }
 
     public CrossOriginResourceSharing(Collection<String> allowedOrigins,
             Collection<String> allowedMethods,
             Collection<String> allowedHeaders,
+            Collection<String> exposedHeaders,
             String allowCredentials) {
         Set<Pattern> allowedPattern = new HashSet<Pattern>();
         boolean anyOriginAllowed = false;
@@ -95,16 +100,29 @@ public final class CrossOriginResourceSharing {
         this.allowedHeadersRaw = Joiner.on(HEADER_VALUE_SEPARATOR).join(
                 this.allowedHeaders);
 
+        if (exposedHeaders == null) {
+            this.exposedHeaders = ImmutableSet.of();
+        } else {
+            this.exposedHeaders = ImmutableSet.copyOf(exposedHeaders);
+        }
+        this.exposedHeadersRaw = Joiner.on(HEADER_VALUE_SEPARATOR).join(
+                this.exposedHeaders);
+
         this.allowCredentials = allowCredentials;
 
         logger.info("CORS allowed origins: {}", allowedOrigins);
         logger.info("CORS allowed methods: {}", allowedMethods);
         logger.info("CORS allowed headers: {}", allowedHeaders);
+        logger.info("CORS exposed headers: {}", exposedHeaders);
         logger.info("CORS allow credentials: {}", allowCredentials);
     }
 
     public String getAllowedMethods() {
         return this.allowedMethodsRaw;
+    }
+
+    public String getExposedHeaders() {
+        return this.exposedHeadersRaw;
     }
 
     public String getAllowedOrigin(String origin) {

--- a/src/main/java/org/gaul/s3proxy/S3Proxy.java
+++ b/src/main/java/org/gaul/s3proxy/S3Proxy.java
@@ -270,6 +270,8 @@ public final class S3Proxy {
                         S3ProxyConstants.PROPERTY_CORS_ALLOW_METHODS, "");
                 String corsAllowHeaders = properties.getProperty(
                         S3ProxyConstants.PROPERTY_CORS_ALLOW_HEADERS, "");
+                String corsExposedHeaders = properties.getProperty(
+                        S3ProxyConstants.PROPERTY_CORS_EXPOSED_HEADERS, "");
                 String allowCredentials = properties.getProperty(
                         S3ProxyConstants.PROPERTY_CORS_ALLOW_CREDENTIAL, "");
 
@@ -292,6 +294,7 @@ public final class S3Proxy {
                         Lists.newArrayList(splitter.split(corsAllowOrigins)),
                         Lists.newArrayList(splitter.split(corsAllowMethods)),
                         Lists.newArrayList(splitter.split(corsAllowHeaders)),
+                        Lists.newArrayList(splitter.split(corsExposedHeaders)),
                         allowCredentials));
             }
 

--- a/src/main/java/org/gaul/s3proxy/S3ProxyConstants.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyConstants.java
@@ -40,6 +40,8 @@ public final class S3ProxyConstants {
             "s3proxy.cors-allow-methods";
     public static final String PROPERTY_CORS_ALLOW_HEADERS =
             "s3proxy.cors-allow-headers";
+    public static final String PROPERTY_CORS_EXPOSED_HEADERS =
+            "s3proxy.cors-exposed-headers";
     public static final String PROPERTY_CORS_ALLOW_CREDENTIAL =
             "s3proxy.cors-allow-credential";
     public static final String PROPERTY_CREDENTIAL =

--- a/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
@@ -1715,6 +1715,11 @@ public class S3ProxyHandler {
         response.addHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS,
                 corsRules.getAllowedMethods());
 
+        String exposedHeaders = corsRules.getExposedHeaders();
+        if (!Strings.isNullOrEmpty(exposedHeaders)) {
+            response.addHeader(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS, exposedHeaders);
+        }
+
         response.setStatus(HttpServletResponse.SC_OK);
     }
 
@@ -3014,6 +3019,8 @@ public class S3ProxyHandler {
                     corsRules.getAllowedOrigin(corsOrigin));
             response.addHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS,
                     corsRules.getAllowedMethods());
+            response.addHeader(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS,
+                    corsRules.getExposedHeaders());
             if (corsRules.isAllowCredentials()) {
                 response.addHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS,
                         "true");

--- a/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
@@ -1717,7 +1717,8 @@ public class S3ProxyHandler {
 
         String exposedHeaders = corsRules.getExposedHeaders();
         if (!Strings.isNullOrEmpty(exposedHeaders)) {
-            response.addHeader(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS, exposedHeaders);
+            response.addHeader(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS,
+                exposedHeaders);
         }
 
         response.setStatus(HttpServletResponse.SC_OK);

--- a/src/main/resources/run-docker-container.sh
+++ b/src/main/resources/run-docker-container.sh
@@ -15,6 +15,7 @@ exec java \
     -Ds3proxy.cors-allow-origins="${S3PROXY_CORS_ALLOW_ORIGINS}" \
     -Ds3proxy.cors-allow-methods="${S3PROXY_CORS_ALLOW_METHODS}" \
     -Ds3proxy.cors-allow-headers="${S3PROXY_CORS_ALLOW_HEADERS}" \
+    -Ds3proxy.cors-exposed-headers="${S3PROXY_CORS_EXPOSED_HEADERS}" \
     -Ds3proxy.cors-allow-credential="${S3PROXY_CORS_ALLOW_CREDENTIAL}" \
     -Ds3proxy.ignore-unknown-headers="${S3PROXY_IGNORE_UNKNOWN_HEADERS}" \
     -Ds3proxy.encrypted-blobstore="${S3PROXY_ENCRYPTED_BLOBSTORE}" \

--- a/src/test/java/org/gaul/s3proxy/CrossOriginResourceSharingAllowAllResponseTest.java
+++ b/src/test/java/org/gaul/s3proxy/CrossOriginResourceSharingAllowAllResponseTest.java
@@ -160,6 +160,11 @@ public final class CrossOriginResourceSharingAllowAllResponseTest {
         assertThat(response.getFirstHeader(
                 HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS).getValue())
                 .isEqualTo("Accept, Content-Type");
+        assertThat(response.containsHeader(
+                HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS)).isTrue();
+        assertThat(response.getFirstHeader(
+                HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS).getValue())
+                .isEqualTo("*");
     }
 
     @Test
@@ -178,7 +183,12 @@ public final class CrossOriginResourceSharingAllowAllResponseTest {
                 HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS)).isTrue();
         assertThat(response.getFirstHeader(
                 HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS).getValue())
-                    .isEqualTo("GET, HEAD, PUT, POST, DELETE");
+                .isEqualTo("GET, HEAD, PUT, POST, DELETE");
+        assertThat(response.containsHeader(
+                HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS)).isTrue();
+        assertThat(response.getFirstHeader(
+                HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS).getValue())
+                .isEqualTo("*");
     }
 
     @Test

--- a/src/test/java/org/gaul/s3proxy/CrossOriginResourceSharingResponseTest.java
+++ b/src/test/java/org/gaul/s3proxy/CrossOriginResourceSharingResponseTest.java
@@ -156,6 +156,9 @@ public final class CrossOriginResourceSharingResponseTest {
         assertThat(response.getFirstHeader(
                 HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS).getValue())
                 .isEqualTo("GET, PUT");
+        assertThat(response.getFirstHeader(
+                HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS).getValue())
+                .isEqualTo("ETag");
 
         // Allowed origin, method and header
         request.reset();
@@ -180,6 +183,9 @@ public final class CrossOriginResourceSharingResponseTest {
         assertThat(response.getFirstHeader(
                 HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS).getValue())
                 .isEqualTo("Accept");
+        assertThat(response.getFirstHeader(
+                HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS).getValue())
+                .isEqualTo("ETag");
 
         // Allowed origin, method and header combination
         request.reset();
@@ -205,6 +211,9 @@ public final class CrossOriginResourceSharingResponseTest {
         assertThat(response.getFirstHeader(
                 HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS).getValue())
                 .isEqualTo("Accept, Content-Type");
+        assertThat(response.getFirstHeader(
+                HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS).getValue())
+                .isEqualTo("ETag");
     }
 
     @Test
@@ -249,6 +258,9 @@ public final class CrossOriginResourceSharingResponseTest {
                 HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS).getValue())
                 .isEqualTo("Accept, Content-Type");
         assertThat(response.getFirstHeader(
+                HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS).getValue())
+                .isEqualTo("ETag");
+        assertThat(response.getFirstHeader(
                 HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS))
                 .isNull();
     }
@@ -270,6 +282,9 @@ public final class CrossOriginResourceSharingResponseTest {
         assertThat(response.getFirstHeader(
                 HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS).getValue())
                     .isEqualTo("GET, PUT");
+        assertThat(response.getFirstHeader(
+                HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS).getValue())
+                .isEqualTo("ETag");
     }
 
     @Test
@@ -280,6 +295,8 @@ public final class CrossOriginResourceSharingResponseTest {
                 .isEqualTo(HttpStatus.SC_OK);
         assertThat(response.containsHeader(
                 HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN)).isFalse();
+        assertThat(response.containsHeader(
+                HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS)).isFalse();
     }
 
     private static String createRandomContainerName() {

--- a/src/test/java/org/gaul/s3proxy/CrossOriginResourceSharingRuleTest.java
+++ b/src/test/java/org/gaul/s3proxy/CrossOriginResourceSharingRuleTest.java
@@ -18,6 +18,8 @@ package org.gaul.s3proxy;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
+
 import com.google.common.collect.Lists;
 
 import org.junit.Before;
@@ -39,7 +41,7 @@ public final class CrossOriginResourceSharingRuleTest {
                         "https://example\\.cloud"),
                 Lists.newArrayList("GET", "PUT"),
                 Lists.newArrayList("Accept", "Content-Type"),
-                Lists.newArrayList(),
+                List.of(),
                 "true");
         // CORS disabled
         corsOff = new CrossOriginResourceSharing(null, null, null, null, null);

--- a/src/test/java/org/gaul/s3proxy/CrossOriginResourceSharingRuleTest.java
+++ b/src/test/java/org/gaul/s3proxy/CrossOriginResourceSharingRuleTest.java
@@ -39,9 +39,10 @@ public final class CrossOriginResourceSharingRuleTest {
                         "https://example\\.cloud"),
                 Lists.newArrayList("GET", "PUT"),
                 Lists.newArrayList("Accept", "Content-Type"),
+                Lists.newArrayList(),
                 "true");
         // CORS disabled
-        corsOff = new CrossOriginResourceSharing(null, null, null, null);
+        corsOff = new CrossOriginResourceSharing(null, null, null, null, null);
     }
 
     @Test

--- a/src/test/resources/s3proxy-cors.conf
+++ b/src/test/resources/s3proxy-cors.conf
@@ -9,6 +9,7 @@ s3proxy.keystore-password=password
 s3proxy.cors-allow-origins=https://example\.com https://.+\.example\.com https://example\.cloud
 s3proxy.cors-allow-methods=GET PUT
 s3proxy.cors-allow-headers=Accept Content-Type
+s3proxy.cors-exposed-headers=ETag
 
 jclouds.provider=transient
 jclouds.identity=remote-identity


### PR DESCRIPTION
Copy/paste of #668 description:

> I mentioned this in issue https://github.com/gaul/s3proxy/issues/667 but suffice to say that, while ETag is available as a header from many of the APIs in S3Proxy, the browser cannot access it since it's missing from the Access-Control-Expose-Headers list. To allow accessing this header from the browser, it needs to be added to the [Access-Control-Expose-Headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers) header.

This PR introduces a new config variable; `s3proxy.cors-exposed-headers` (or `S3PROXY_CORS_EXPOSED_HEADERS`) that allows configuring the values returned with `Access-Control-Expose-Headers` for CORS.