### PR TITLE
Allow x-amz-user-agent header

### DIFF
--- a/src/main/java/org/gaul/s3proxy/AwsHttpHeaders.java
+++ b/src/main/java/org/gaul/s3proxy/AwsHttpHeaders.java
@@ -35,6 +35,7 @@ final class AwsHttpHeaders {
     static final String METADATA_DIRECTIVE = "x-amz-metadata-directive";
     static final String REQUEST_ID = "x-amz-request-id";
     static final String STORAGE_CLASS = "x-amz-storage-class";
+    static final String USER_AGENT = "x-amz-user-agent";
 
     private AwsHttpHeaders() {
         throw new AssertionError("intentionally unimplemented");

--- a/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
@@ -173,7 +173,8 @@ public class S3ProxyHandler {
             AwsHttpHeaders.DATE,
             AwsHttpHeaders.DECODED_CONTENT_LENGTH,
             AwsHttpHeaders.METADATA_DIRECTIVE,
-            AwsHttpHeaders.STORAGE_CLASS
+            AwsHttpHeaders.STORAGE_CLASS,
+            AwsHttpHeaders.USER_AGENT
     );
     private static final Set<String> CANNED_ACLS = ImmutableSet.of(
             "private",


### PR DESCRIPTION
The Rust S3 SDK `aws-sdk-s3` (https://github.com/awslabs/aws-sdk-rust) sends the `x-amz-user-agent` header, but `s3proxy` does not know about it. This causes s3proxy to reject all requests from `aws-sdk-s3`.

This patch adds `x-amz-user-agent` to the `SUPPORTED_X_AMZ_HEADERS` list.