### PR TITLE
Add middleware to replace user metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ S3Proxy can modify its behavior based on middlewares:
 * [regex rename blobs](https://github.com/gaul/s3proxy/wiki/Middleware-regex)
 * [sharded backend containers](https://github.com/gaul/s3proxy/wiki/Middleware-sharded-backend)
 * [storage class override](https://github.com/gaul/s3proxy/wiki/Middleware-storage-class-override)
+* user metadata replacer
 
 ## SSL Support
 

--- a/src/main/java/org/gaul/s3proxy/Main.java
+++ b/src/main/java/org/gaul/s3proxy/Main.java
@@ -283,6 +283,19 @@ public final class Main {
                     StorageClass.fromTier(storageClassBlobStore.getTier()));
         }
 
+        String userMetadataReplacerBlobStore = properties.getProperty(
+                S3ProxyConstants.PROPERTY_USER_METADATA_REPLACER);
+        if ("true".equalsIgnoreCase(userMetadataReplacerBlobStore)) {
+            System.err.println("Using user metadata replacers storage backend");
+            String fromChars = properties.getProperty(S3ProxyConstants
+                    .PROPERTY_USER_METADATA_REPLACER_FROM_CHARS);
+            String toChars = properties.getProperty(S3ProxyConstants
+                    .PROPERTY_USER_METADATA_REPLACER_TO_CHARS);
+            blobStore = UserMetadataReplacerBlobStore
+                    .newUserMetadataReplacerBlobStore(
+                            blobStore, fromChars, toChars);
+        }
+
         return blobStore;
     }
 

--- a/src/main/java/org/gaul/s3proxy/S3ProxyConstants.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyConstants.java
@@ -128,6 +128,13 @@ public final class S3ProxyConstants {
     public static final String PROPERTY_ENCRYPTED_BLOBSTORE_SALT =
             "s3proxy.encrypted-blobstore-salt";
 
+    public static final String PROPERTY_USER_METADATA_REPLACER =
+            "s3proxy.user-metadata-replacer-blobstore";
+    public static final String PROPERTY_USER_METADATA_REPLACER_FROM_CHARS =
+            "s3proxy.user-metadata-replacer-blobstore.from-chars";
+    public static final String PROPERTY_USER_METADATA_REPLACER_TO_CHARS =
+            "s3proxy.user-metadata-replacer-blobstore.to-chars";
+
     static final String PROPERTY_ALT_JCLOUDS_PREFIX = "alt.";
 
     private S3ProxyConstants() {

--- a/src/main/java/org/gaul/s3proxy/UserMetadataReplacerBlobStore.java
+++ b/src/main/java/org/gaul/s3proxy/UserMetadataReplacerBlobStore.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2014-2021 Andrew Gaul <andrew@gaul.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gaul.s3proxy;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.common.collect.ImmutableMap;
+
+import org.jclouds.blobstore.BlobStore;
+import org.jclouds.blobstore.domain.Blob;
+import org.jclouds.blobstore.domain.BlobMetadata;
+import org.jclouds.blobstore.domain.MultipartUpload;
+import org.jclouds.blobstore.domain.MutableBlobMetadata;
+import org.jclouds.blobstore.options.GetOptions;
+import org.jclouds.blobstore.options.PutOptions;
+import org.jclouds.blobstore.util.ForwardingBlobStore;
+
+/**
+ * BlobStore which maps user metadata keys and values using character
+ * replacement.  This is useful for some object stores like Azure which do not
+ * allow characters like hyphens.  This munges keys and values during putBlob
+ * and unmunges them on getBlob.
+ */
+final class UserMetadataReplacerBlobStore extends ForwardingBlobStore {
+    private final String fromChars;
+    private final String toChars;
+
+    private UserMetadataReplacerBlobStore(
+            BlobStore blobStore, String fromChars, String toChars) {
+        super(blobStore);
+        checkArgument(fromChars.length() == toChars.length());
+        this.fromChars = fromChars;
+        this.toChars = toChars;
+    }
+
+    public static BlobStore newUserMetadataReplacerBlobStore(
+            BlobStore blobStore, String fromChars, String toChars) {
+        return new UserMetadataReplacerBlobStore(blobStore, fromChars, toChars);
+    }
+
+    @Override
+    public String putBlob(String containerName, Blob blob) {
+        return putBlob(containerName, blob, new PutOptions());
+    }
+
+    @Override
+    public String putBlob(String containerName, Blob blob,
+            PutOptions putOptions) {
+        var metadata = ImmutableMap.<String, String>builder();
+        for (var entry : blob.getMetadata().getUserMetadata().entrySet()) {
+            metadata.put(replaceChars(entry.getKey(), fromChars, toChars),
+                    replaceChars(entry.getValue(), fromChars, toChars));
+        }
+        // TODO: should this modify the parameter?
+        blob.getMetadata().setUserMetadata(metadata.build());
+        return super.putBlob(containerName, blob, putOptions);
+    }
+
+    @Override
+    public BlobMetadata blobMetadata(String container, String name) {
+        var blobMetadata = super.blobMetadata(container, name);
+        var metadata = ImmutableMap.<String, String>builder();
+        // TODO: duplication
+        for (var entry : blobMetadata.getUserMetadata().entrySet()) {
+            metadata.put(replaceChars(entry.getKey(), toChars, fromChars),
+                    replaceChars(entry.getValue(), toChars, fromChars));
+        }
+        ((MutableBlobMetadata) blobMetadata).setUserMetadata(metadata.build());
+        return blobMetadata;
+    }
+
+    @Override
+    public Blob getBlob(String containerName, String name) {
+        return getBlob(containerName, name, new GetOptions());
+    }
+
+    @Override
+    public Blob getBlob(String containerName, String name,
+            GetOptions getOptions) {
+        var blob = super.getBlob(containerName, name, getOptions);
+        var metadata = ImmutableMap.<String, String>builder();
+        for (var entry : blob.getMetadata().getUserMetadata().entrySet()) {
+            metadata.put(replaceChars(entry.getKey(), toChars, fromChars),
+                    replaceChars(entry.getValue(), toChars, fromChars));
+        }
+        blob.getMetadata().setUserMetadata(metadata.build());
+        return blob;
+    }
+
+    public MultipartUpload initiateMultipartUpload(String container,
+            BlobMetadata blobMetadata, PutOptions overrides) {
+        var metadata = ImmutableMap.<String, String>builder();
+        for (var entry : blobMetadata.getUserMetadata().entrySet()) {
+            metadata.put(replaceChars(entry.getKey(), fromChars, toChars),
+                    replaceChars(entry.getValue(), fromChars, toChars));
+        }
+        ((MutableBlobMetadata) blobMetadata).setUserMetadata(metadata.build());
+        return super.initiateMultipartUpload(container, blobMetadata,
+                overrides);
+    }
+
+    private static String replaceChars(String value, String fromChars,
+            String toChars) {
+        var builder = new StringBuilder(/*capacity=*/ value.length());
+        for (int i = 0; i < value.length(); ++i) {
+            for (int j = 0; j < fromChars.length(); ++j) {
+                builder.append(value.charAt(i) == fromChars.charAt(j) ?
+                        toChars.charAt(j) : value.charAt(i));
+            }
+        }
+        return builder.toString();
+    }
+}

--- a/src/test/java/org/gaul/s3proxy/UserMetadataReplacerBlobStoreTest.java
+++ b/src/test/java/org/gaul/s3proxy/UserMetadataReplacerBlobStoreTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2014-2021 Andrew Gaul <andrew@gaul.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gaul.s3proxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+
+import org.jclouds.ContextBuilder;
+import org.jclouds.blobstore.BlobStore;
+import org.jclouds.blobstore.BlobStoreContext;
+import org.jclouds.blobstore.options.PutOptions;
+import org.jclouds.logging.slf4j.config.SLF4JLoggingModule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@SuppressWarnings("UnstableApiUsage")
+public final class UserMetadataReplacerBlobStoreTest {
+    private static final Logger logger =
+            LoggerFactory.getLogger(UserMetadataReplacerBlobStoreTest.class);
+
+    private BlobStoreContext context;
+    private BlobStore blobStore;
+    private String containerName;
+    // TODO: better name?
+    private BlobStore userMetadataReplacerBlobStore;
+
+    @Before
+    public void setUp() throws Exception {
+        containerName = TestUtils.createRandomContainerName();
+
+        //noinspection UnstableApiUsage
+        context = ContextBuilder
+                .newBuilder("transient")
+                .credentials("identity", "credential")
+                .modules(List.of(new SLF4JLoggingModule()))
+                .build(BlobStoreContext.class);
+        blobStore = context.getBlobStore();
+        blobStore.createContainerInLocation(null, containerName);
+
+        userMetadataReplacerBlobStore = UserMetadataReplacerBlobStore
+                .newUserMetadataReplacerBlobStore(blobStore, "-", "_");
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (context != null) {
+            blobStore.deleteContainer(containerName);
+            context.close();
+        }
+    }
+
+    @Test
+    public void testPutNewBlob() {
+        var blobName = TestUtils.createRandomBlobName();
+        var content = TestUtils.randomByteSource().slice(0, 1024);
+        var blob = userMetadataReplacerBlobStore.blobBuilder(blobName)
+                .payload(content)
+                .userMetadata(Map.of("my-key", "my-value-"))
+                .build();
+        userMetadataReplacerBlobStore.putBlob(containerName, blob);
+
+        // check underlying blobStore
+        var mutableBlobMetadata = blobStore.getBlob(containerName, blobName)
+                .getMetadata();
+        var userMetadata = mutableBlobMetadata.getUserMetadata();
+        assertThat(userMetadata).hasSize(1);
+        var entry = userMetadata.entrySet().iterator().next();
+        assertThat(entry.getKey()).isEqualTo("my_key");
+        assertThat(entry.getValue()).isEqualTo("my_value_");
+
+        // check getBlob
+        mutableBlobMetadata = userMetadataReplacerBlobStore.getBlob(
+                containerName, blobName).getMetadata();
+        userMetadata = mutableBlobMetadata.getUserMetadata();
+        assertThat(userMetadata).hasSize(1);
+        entry = userMetadata.entrySet().iterator().next();
+        assertThat(entry.getKey()).isEqualTo("my-key");
+        assertThat(entry.getValue()).isEqualTo("my-value-");
+
+        // check blobMetadata
+        var blobMetadata = userMetadataReplacerBlobStore.blobMetadata(
+                containerName, blobName);
+        userMetadata = blobMetadata.getUserMetadata();
+        assertThat(userMetadata).hasSize(1);
+        entry = userMetadata.entrySet().iterator().next();
+        assertThat(entry.getKey()).isEqualTo("my-key");
+        assertThat(entry.getValue()).isEqualTo("my-value-");
+    }
+
+    @Test
+    public void testPutNewMultipartBlob() {
+        var blobName = TestUtils.createRandomBlobName();
+        var content = TestUtils.randomByteSource().slice(0, 1024);
+        var blob = userMetadataReplacerBlobStore.blobBuilder(blobName)
+                .payload(content)
+                .userMetadata(Map.of("my-key", "my-value-"))
+                .build();
+        var mpu = userMetadataReplacerBlobStore.initiateMultipartUpload(
+                containerName, blob.getMetadata(), new PutOptions());
+        var part = userMetadataReplacerBlobStore.uploadMultipartPart(
+                mpu, 1, blob.getPayload());
+        userMetadataReplacerBlobStore.completeMultipartUpload(
+                mpu, List.of(part));
+
+        // check underlying blobStore
+        var mutableBlobMetadata = blobStore.getBlob(containerName, blobName)
+                .getMetadata();
+        var userMetadata = mutableBlobMetadata.getUserMetadata();
+        assertThat(userMetadata).hasSize(1);
+        var entry = userMetadata.entrySet().iterator().next();
+        assertThat(entry.getKey()).isEqualTo("my_key");
+        assertThat(entry.getValue()).isEqualTo("my_value_");
+
+        // check getBlob
+        mutableBlobMetadata = userMetadataReplacerBlobStore.getBlob(
+                containerName, blobName).getMetadata();
+        userMetadata = mutableBlobMetadata.getUserMetadata();
+        assertThat(userMetadata).hasSize(1);
+        entry = userMetadata.entrySet().iterator().next();
+        assertThat(entry.getKey()).isEqualTo("my-key");
+        assertThat(entry.getValue()).isEqualTo("my-value-");
+
+        // check blobMetadata
+        var blobMetadata = userMetadataReplacerBlobStore.blobMetadata(
+                containerName, blobName);
+        userMetadata = blobMetadata.getUserMetadata();
+        assertThat(userMetadata).hasSize(1);
+        entry = userMetadata.entrySet().iterator().next();
+        assertThat(entry.getKey()).isEqualTo("my-key");
+        assertThat(entry.getValue()).isEqualTo("my-value-");
+    }
+}


### PR DESCRIPTION
This is useful when keys and values must conform to some subset of values, e.g., Azure's C# identifiers.  Fixes #466.