### PR TITLE
Allow setting service-path config when running via Docker

### DIFF
--- a/src/main/resources/run-docker-container.sh
+++ b/src/main/resources/run-docker-container.sh
@@ -24,6 +24,7 @@ exec java \
     -Ds3proxy.v4-max-non-chunked-request-size="${S3PROXY_V4_MAX_NON_CHUNKED_REQ_SIZE:-33554432}" \
     -Ds3proxy.read-only-blobstore="${S3PROXY_READ_ONLY_BLOBSTORE:-false}" \
     -Ds3proxy.maximum-timeskew="${S3PROXY_MAXIMUM_TIMESKEW}" \
+    -Ds3proxy.service-path="${S3PROXY_SERVICE_PATH}" \
     -Djclouds.provider="${JCLOUDS_PROVIDER}" \
     -Djclouds.identity="${JCLOUDS_IDENTITY}" \
     -Djclouds.credential="${JCLOUDS_CREDENTIAL}" \


### PR DESCRIPTION
This update allows the `s3proxy.service-path` configuration introduced in https://github.com/gaul/s3proxy/pull/194 to be set when running S3Proxy via Docker