### PR TITLE
Set outputLength correctly on open ended range requests to encryptedBlobStore

### DIFF
--- a/src/main/java/org/gaul/s3proxy/crypto/Decryption.java
+++ b/src/main/java/org/gaul/s3proxy/crypto/Decryption.java
@@ -136,8 +136,8 @@ public class Decryption {
         // calculate the offset
         calculateOffset(offset);
 
-        // if there is a offset and a length set the output length
-        if (offset > 0 && length == 0) {
+        // if there is a offset and no length set the output length
+        if (offset > 0 && length <= 0) {
             outputLength = unencryptedSize - offset;
         }
     }

--- a/src/test/java/org/gaul/s3proxy/EncryptedBlobStoreLiveTest.java
+++ b/src/test/java/org/gaul/s3proxy/EncryptedBlobStoreLiveTest.java
@@ -159,12 +159,16 @@ public final class EncryptedBlobStoreLiveTest extends S3ClientLiveTest {
         options.range(0, 19);
         object = this.getApi().getObject(containerName, blobName, options);
 
-        InputStreamReader r =
-            new InputStreamReader(object.getPayload().openStream());
+        InputStreamReader r = new InputStreamReader(
+                object.getPayload().openStream());
         BufferedReader reader = new BufferedReader(r);
-        String partialContent = reader.lines().collect(Collectors.joining());
-        assertThat(partialContent).isEqualTo(content.substring(0, 20));
-        assertThat((long) partialContent.length()).isEqualTo(object.getMetadata().getContentMetadata().getContentLength());
+        String partialContent = reader.lines()
+                .collect(Collectors.joining());
+
+        assertThat(partialContent).isEqualTo(
+                content.substring(0, 20));
+        assertThat((long) partialContent.length()).isEqualTo(
+                object.getMetadata().getContentMetadata().getContentLength());
 
         // open ended range request
         options = new GetOptions();
@@ -174,8 +178,10 @@ public final class EncryptedBlobStoreLiveTest extends S3ClientLiveTest {
         r = new InputStreamReader(object.getPayload().openStream());
         reader = new BufferedReader(r);
         partialContent = reader.lines().collect(Collectors.joining());
+
         assertThat(partialContent).isEqualTo(content.substring(10));
-        assertThat((long) partialContent.length()).isEqualTo(object.getMetadata().getContentMetadata().getContentLength());
+        assertThat((long) partialContent.length()).isEqualTo(
+                object.getMetadata().getContentMetadata().getContentLength());
     }
 
     @Test

--- a/src/test/java/org/gaul/s3proxy/EncryptedBlobStoreLiveTest.java
+++ b/src/test/java/org/gaul/s3proxy/EncryptedBlobStoreLiveTest.java
@@ -164,6 +164,18 @@ public final class EncryptedBlobStoreLiveTest extends S3ClientLiveTest {
         BufferedReader reader = new BufferedReader(r);
         String partialContent = reader.lines().collect(Collectors.joining());
         assertThat(partialContent).isEqualTo(content.substring(0, 20));
+        assertThat((long) partialContent.length()).isEqualTo(object.getMetadata().getContentMetadata().getContentLength());
+
+        // open ended range request
+        options = new GetOptions();
+        options.startAt(10);
+        object = this.getApi().getObject(containerName, blobName, options);
+
+        r = new InputStreamReader(object.getPayload().openStream());
+        reader = new BufferedReader(r);
+        partialContent = reader.lines().collect(Collectors.joining());
+        assertThat(partialContent).isEqualTo(content.substring(10));
+        assertThat((long) partialContent.length()).isEqualTo(object.getMetadata().getContentMetadata().getContentLength());
     }
 
     @Test


### PR DESCRIPTION
This resolves https://github.com/gaul/s3proxy/issues/698.

Open ended ranged requests to encrypted files resulted in incorrect Content-Length headers in the response because of a bug in the Decryption class.

In EncryptedBloBStore the length is set to `-1` by default. On open-ended ranged GET requests this value is passed to the `Decryption` constructor, which in turn only sets `outputLength` if an `offset` is given without a `length`, but `-1` is used to represent no length given. After this change the `outputLength` is set correctly in this constructor.

https://github.com/gaul/s3proxy/blob/master/src/main/java/org/gaul/s3proxy/EncryptedBlobStore.java#L375

@gaul The tests pass (locally) but I have not spend enough time with this codebase to reason about whether this change will break anything else (which is currently untested). Is this a reasonable solution for https://github.com/gaul/s3proxy/issues/698?