### PR TITLE
Allow to use Azure managed identities for azureblob-sdk backend

### DIFF
--- a/src/main/java/org/gaul/s3proxy/azureblob/AzureBlobStore.java
+++ b/src/main/java/org/gaul/s3proxy/azureblob/AzureBlobStore.java
@@ -33,6 +33,7 @@ import javax.annotation.Nullable;
 
 import com.azure.core.credential.AzureNamedKeyCredential;
 import com.azure.core.http.rest.PagedResponse;
+import com.azure.identity.DefaultAzureCredentialBuilder;
 import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.BlobServiceClientBuilder;
 import com.azure.storage.blob.models.AccessTier;
@@ -123,9 +124,15 @@ public final class AzureBlobStore extends BaseBlobStore {
                 /*tryTimeoutInSeconds=*/ (Integer) null,
                 /*retryDelayInMs=*/ null, /*maxRetryDelayInMs=*/ null,
                 /*secondaryHost=*/ null);
-        blobServiceClient = new BlobServiceClientBuilder()
-                .credential(new AzureNamedKeyCredential(
-                        cred.identity, cred.credential))
+        var blobServiceClientBuilder = new BlobServiceClientBuilder();
+        if (!cred.identity.isEmpty() && !cred.credential.isEmpty()) {
+            blobServiceClientBuilder.credential(
+                new AzureNamedKeyCredential(cred.identity, cred.credential));
+        } else {
+            blobServiceClientBuilder.credential(
+                new DefaultAzureCredentialBuilder().build());
+        }
+        blobServiceClient = blobServiceClientBuilder
                 .endpoint(endpoint)
                 .retryOptions(retryOptions)
                 .buildClient();


### PR DESCRIPTION
This PR closes #352, #536.

Current behaviour is unaffected. If backend provider is `azureblob-sdk`, and both `identity`, and `credentials` are empty strings, authentication fallbacks to [DefaultAzureCredential](https://learn.microsoft.com/en-us/java/api/com.azure.identity.defaultazurecredential?view=azure-java-stable) and tries to login with multiple approaches, including managed identities.