### PR TITLE
Upgrade to commons-fileupload2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -465,9 +465,9 @@
       <version>3.0.2</version>
     </dependency>
     <dependency>
-      <groupId>commons-fileupload</groupId>
-      <artifactId>commons-fileupload</artifactId>
-      <version>1.5</version>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-fileupload2-javax</artifactId>
+      <version>2.0.0-M2</version>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>

--- a/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
@@ -82,7 +82,7 @@ import com.google.common.net.PercentEscaper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-import org.apache.commons.fileupload.MultipartStream;
+import org.apache.commons.fileupload2.core.MultipartInput;
 import org.jclouds.blobstore.BlobStore;
 import org.jclouds.blobstore.KeyNotFoundException;
 import org.jclouds.blobstore.domain.Blob;
@@ -2051,8 +2051,10 @@ public class S3ProxyHandler {
         String signature = null;
         String algorithm = null;
         byte[] payload = null;
-        var multipartStream = new MultipartStream(is,
-                boundary.getBytes(StandardCharsets.UTF_8), 4096, null);
+        var multipartStream = MultipartInput.builder()
+                .setBoundary(boundary.getBytes(StandardCharsets.UTF_8))
+                .setInputStream(is)
+                .get();
         boolean nextPart = multipartStream.skipPreamble();
         while (nextPart) {
             String header = multipartStream.readHeaders();


### PR DESCRIPTION
This indirectly addresses a CVE in commons-io that does not affect S3Proxy.