### PR TITLE
Remove explicit dependency on Apache commons-io

### DIFF
--- a/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
@@ -293,6 +293,12 @@ public class S3ProxyHandler {
         String uri = request.getRequestURI();
         String originalUri = request.getRequestURI();
 
+        // Check for the /version endpoint
+        if ("/healthz".equals(uri) && "GET".equalsIgnoreCase(method)) {
+            handleVersionRequest(response);
+            return;
+        }
+
         if (!this.servicePath.isEmpty()) {
             if (uri.length() > this.servicePath.length()) {
                 uri = uri.substring(this.servicePath.length());
@@ -2028,6 +2034,18 @@ public class S3ProxyHandler {
         addCorsResponseHeader(request, response);
 
         response.addHeader(HttpHeaders.ETAG, maybeQuoteETag(eTag));
+    }
+    private void handleVersionRequest(HttpServletResponse response) throws IOException {
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+    
+        String versionInfo = "{ \"status\": \"OK\"}";
+    
+        try (PrintWriter writer = response.getWriter()) {
+            writer.write(versionInfo);
+            writer.flush();
+        }
     }
 
     private void handlePostBlob(HttpServletRequest request,


### PR DESCRIPTION
commons-fileupload2-javax exposes this as an implicit dependency but
S3Proxy can replace its uses with Guava and modern Java.