### PR TITLE
docker: Match s3proxy.v4-max-non-chunked-request-size default (128 MB)

### DIFF
--- a/src/main/resources/run-docker-container.sh
+++ b/src/main/resources/run-docker-container.sh
@@ -23,7 +23,7 @@ exec java \
     -Ds3proxy.encrypted-blobstore="${S3PROXY_ENCRYPTED_BLOBSTORE}" \
     -Ds3proxy.encrypted-blobstore-password="${S3PROXY_ENCRYPTED_BLOBSTORE_PASSWORD}" \
     -Ds3proxy.encrypted-blobstore-salt="${S3PROXY_ENCRYPTED_BLOBSTORE_SALT}" \
-    -Ds3proxy.v4-max-non-chunked-request-size="${S3PROXY_V4_MAX_NON_CHUNKED_REQ_SIZE:-33554432}" \
+    -Ds3proxy.v4-max-non-chunked-request-size="${S3PROXY_V4_MAX_NON_CHUNKED_REQ_SIZE:-134217728}" \
     -Ds3proxy.read-only-blobstore="${S3PROXY_READ_ONLY_BLOBSTORE:-false}" \
     -Ds3proxy.maximum-timeskew="${S3PROXY_MAXIMUM_TIMESKEW}" \
     -Ds3proxy.service-path="${S3PROXY_SERVICE_PATH}" \


### PR DESCRIPTION
- https://github.com/gaul/s3proxy/pull/594 changed the hardcoded default value of `v4MaxNonChunkedRequestSize` to 128 MB
- The 128 MB default only kicks in if the `s3proxy.v4-max-non-chunked-request-size` config is not set
- However, when using the Docker image (in k8s, for example), if you don't explicitly override the `S3PROXY_V4_MAX_NON_CHUNKED_REQ_SIZE` env variable, the `run-docker-container.sh` sets this env var [1] to a default of 33554432 bytes (~32 MB)
- This commit changes this defualt to 128 MB, to match the default value defined in the code itself

This change makes it such that an un-initiated user running s3Proxy via Docker / k8s does not run into an error of the form:

400 MaxMessageLengthExceeded Your request was too big

, when uploading a file between 32 - 128 MB.

[1] https://github.com/gaul/s3proxy/blob/master/src/main/resources/run-docker-container.sh#L26