### PR TITLE
Docker: Use dumb-init as init system

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@ LABEL maintainer="Andrew Gaul <andrew@gaul.org>"
 
 WORKDIR /opt/s3proxy
 
+RUN apt-get update && \
+    apt-get install -y dumb-init && \
+    rm -rf /var/lib/apt/lists/*
+
 COPY \
     target/s3proxy \
     src/main/resources/run-docker-container.sh \
@@ -39,4 +43,7 @@ ENV \
     JCLOUDS_FILESYSTEM_BASEDIR="/data"
 
 EXPOSE 80 443
-ENTRYPOINT ["/opt/s3proxy/run-docker-container.sh"]
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+
+CMD ["/opt/s3proxy/run-docker-container.sh"]


### PR DESCRIPTION
PID 1 is special in Linux kernels; do not start the `java` process as PID 1. Instead, use dumb-init [1] as the init system and start it at PID 1.

This is generally done for two main reasons [1]:

- Signal handling When k8s terminates a Pod, it sends a SIGTERM to PID 1 in the containers. When a non-PID-1 process receives SIGTERM and it does not register a SIGTERM handler, the kernel will fall back to the default behavior for a SIGTERM signal: killing the process.

However, this is not the case for PID 1; the kernel does not fallback to killing the PID 1 process if no SIGTERM handler is registered. This means that the SIGTERM will have no effect on the process. k8s will wait for `terminationGracePeriodSeconds` (default: 30 seconds) and only then SIGKILL the process (having wasted 30 seconds where nothing useful was happening).

With `Java` as PID 1 though, I don't run into this issue. Even though s3Proxy does not register a SIGTERM handler, it seems like the JVM does react to the SIGTERM and immediately kills s3Proxy.

Still, let's use dumb-init as a best-practice. Init-systems like dumb-init take the responsibliity for properly registering signal handlers and passing signals to children processes correctly.

- Orphaned processes Any running process that becomes an orphan (parent process dies) is adopted by PID 1. This means PID 1 is responsible for cleaning up (reaping) the orphan process after it has terminated (become zombie /defunct) However, Java as PID 1 will not know about these zombie processes and will not reap them. Using dumb-init will reap such processes.

This is a non-breaking change; users of the docker image do not need any action on their part.

[1] https://engineeringblog.yelp.com/2016/01/dumb-init-an-init-for-docker.html
[2] https://daveiscoding.hashnode.dev/why-do-you-need-an-init-process-inside-your-docker-container-pid-1