### PR TITLE
Check supported headers before signature

### DIFF
--- a/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
@@ -476,6 +476,34 @@ public class S3ProxyHandler {
             path[i] = URLDecoder.decode(path[i], StandardCharsets.UTF_8);
         }
 
+        for (String parameter : Collections.list(
+                request.getParameterNames())) {
+            if (UNSUPPORTED_PARAMETERS.contains(parameter)) {
+                logger.error("Unknown parameters {} with URI {}",
+                        parameter, request.getRequestURI());
+                throw new S3Exception(S3ErrorCode.NOT_IMPLEMENTED);
+            }
+        }
+
+        // emit NotImplemented for unknown x-amz- headers
+        for (String headerName : Collections.list(request.getHeaderNames())) {
+            headerName = headerName.toLowerCase();
+            if (ignoreUnknownHeaders) {
+                continue;
+            }
+            if (!headerName.startsWith("x-amz-")) {
+                continue;
+            }
+            if (headerName.startsWith(USER_METADATA_PREFIX)) {
+                continue;
+            }
+            if (!SUPPORTED_X_AMZ_HEADERS.contains(headerName)) {
+                logger.error("Unknown header {} with URI {}",
+                        headerName, request.getRequestURI());
+                throw new S3Exception(S3ErrorCode.NOT_IMPLEMENTED);
+            }
+        }
+
         Map.Entry<String, BlobStore> provider =
                 blobStoreLocator.locateBlobStore(
                         requestIdentity, path.length > 1 ? path[1] : null,
@@ -617,33 +645,6 @@ public class S3ProxyHandler {
             if (!method.equals("OPTIONS") && !constantTimeEquals(
                     expectedSignature, authHeader.getSignature())) {
                 throw new S3Exception(S3ErrorCode.SIGNATURE_DOES_NOT_MATCH);
-            }
-        }
-
-        for (String parameter : Collections.list(
-                request.getParameterNames())) {
-            if (UNSUPPORTED_PARAMETERS.contains(parameter)) {
-                logger.error("Unknown parameters {} with URI {}",
-                        parameter, request.getRequestURI());
-                throw new S3Exception(S3ErrorCode.NOT_IMPLEMENTED);
-            }
-        }
-
-        // emit NotImplemented for unknown x-amz- headers
-        for (String headerName : Collections.list(request.getHeaderNames())) {
-            if (ignoreUnknownHeaders) {
-                continue;
-            }
-            if (!headerName.startsWith("x-amz-")) {
-                continue;
-            }
-            if (headerName.startsWith(USER_METADATA_PREFIX)) {
-                continue;
-            }
-            if (!SUPPORTED_X_AMZ_HEADERS.contains(headerName.toLowerCase())) {
-                logger.error("Unknown header {} with URI {}",
-                        headerName, request.getRequestURI());
-                throw new S3Exception(S3ErrorCode.NOT_IMPLEMENTED);
             }
         }
 


### PR DESCRIPTION
This gives better errors.  Also use case-insensitive comparisons.