### PR TITLE
fix: service path expected uri for signature to match.

### DIFF
--- a/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
@@ -630,8 +630,8 @@ public class S3ProxyHandler {
                         is = new ByteArrayInputStream(payload);
                     }
 
-                    String uriForSigning = presignedUrl ? originalUri :
-                            this.servicePath + originalUri;
+                    String uriForSigning = presignedUrl ? uri :
+                            this.servicePath + uri;
                     expectedSignature = AwsSignature
                             .createAuthorizationSignatureV4(// v4 sign
                             baseRequest, authHeader, payload, uriForSigning,


### PR DESCRIPTION
Using authentication with a service path (e.g. under kubernetes deployment) does not work, as the expected uri is incorrect (contains the service path twice).