### PR TITLE
Run on Ubuntu OpenJDK 21 JRE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM docker.io/library/eclipse-temurin:17-jre
+FROM docker.io/library/ubuntu:24.04
 LABEL maintainer="Andrew Gaul <andrew@gaul.org>"
 
 WORKDIR /opt/s3proxy
 
 RUN apt-get update && \
-    apt-get install -y dumb-init && \
+    apt-get install -y dumb-init openjdk-21-jre-headless && \
     rm -rf /var/lib/apt/lists/*
 
 COPY \


### PR DESCRIPTION
OpenJDK 21 is the current LTS version. This provides for example improved GC performance compared to OpenJDK 17.

This only increases the runtime JRE version for the provided Docker container, thus the Java code and build itself stays with compatibility on version 11 but at runtime the newer JVM benefits can still already be used.

Alternative to https://github.com/gaul/s3proxy/pull/826 where `linux/arm/v7` would be dropped, this one retains all current architectures but switches the OpenJDK build from Temurin to Ubuntu builds.