### PR TITLE
Add latency blobstore middleware

### DIFF
--- a/src/main/java/org/gaul/s3proxy/LatencyBlobStore.java
+++ b/src/main/java/org/gaul/s3proxy/LatencyBlobStore.java
@@ -16,15 +16,8 @@
 
 package org.gaul.s3proxy;
 
-import com.google.common.collect.ImmutableMap;
-import org.jclouds.blobstore.BlobStore;
-import org.jclouds.blobstore.domain.*;
-import org.jclouds.blobstore.options.*;
-import org.jclouds.blobstore.util.ForwardingBlobStore;
-import org.jclouds.domain.Location;
-import org.jclouds.io.ContentMetadata;
-import org.jclouds.io.Payload;
-import org.jclouds.io.payloads.InputStreamPayload;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
 
 import java.io.File;
 import java.io.IOException;
@@ -37,8 +30,27 @@ import java.util.concurrent.ExecutorService;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static java.util.Objects.requireNonNull;
+import com.google.common.collect.ImmutableMap;
+
+import org.jclouds.blobstore.BlobStore;
+import org.jclouds.blobstore.domain.Blob;
+import org.jclouds.blobstore.domain.BlobAccess;
+import org.jclouds.blobstore.domain.BlobMetadata;
+import org.jclouds.blobstore.domain.ContainerAccess;
+import org.jclouds.blobstore.domain.MultipartPart;
+import org.jclouds.blobstore.domain.MultipartUpload;
+import org.jclouds.blobstore.domain.PageSet;
+import org.jclouds.blobstore.domain.StorageMetadata;
+import org.jclouds.blobstore.options.CopyOptions;
+import org.jclouds.blobstore.options.CreateContainerOptions;
+import org.jclouds.blobstore.options.GetOptions;
+import org.jclouds.blobstore.options.ListContainerOptions;
+import org.jclouds.blobstore.options.PutOptions;
+import org.jclouds.blobstore.util.ForwardingBlobStore;
+import org.jclouds.domain.Location;
+import org.jclouds.io.ContentMetadata;
+import org.jclouds.io.Payload;
+import org.jclouds.io.payloads.InputStreamPayload;
 
 public final class LatencyBlobStore extends ForwardingBlobStore {
     private static final Pattern PROPERTIES_LATENCY_RE = Pattern.compile(
@@ -131,6 +143,18 @@ public final class LatencyBlobStore extends ForwardingBlobStore {
     }
 
     @Override
+    public PageSet<? extends StorageMetadata> list(String container) {
+        simulateLatency(OP_LIST);
+        return super.list(container);
+    }
+
+    @Override
+    public PageSet<? extends StorageMetadata> list(String container, ListContainerOptions options) {
+        simulateLatency(OP_LIST);
+        return super.list(container, options);
+    }
+
+    @Override
     public boolean containerExists(String container) {
         simulateLatency(OP_CONTAINER_EXISTS);
         return super.containerExists(container);
@@ -158,18 +182,6 @@ public final class LatencyBlobStore extends ForwardingBlobStore {
     public void setContainerAccess(String container, ContainerAccess containerAccess) {
         simulateLatency(OP_CONTAINER_ACCESS);
         super.setContainerAccess(container, containerAccess);
-    }
-
-    @Override
-    public PageSet<? extends StorageMetadata> list(String container) {
-        simulateLatency(OP_LIST);
-        return super.list(container);
-    }
-
-    @Override
-    public PageSet<? extends StorageMetadata> list(String container, ListContainerOptions options) {
-        simulateLatency(OP_LIST);
-        return super.list(container, options);
     }
 
     @Override

--- a/src/main/java/org/gaul/s3proxy/LatencyBlobStore.java
+++ b/src/main/java/org/gaul/s3proxy/LatencyBlobStore.java
@@ -1,0 +1,451 @@
+/*
+ * Copyright 2014-2025 Andrew Gaul <andrew@gaul.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gaul.s3proxy;
+
+import com.google.common.collect.ImmutableMap;
+import org.jclouds.blobstore.BlobStore;
+import org.jclouds.blobstore.domain.*;
+import org.jclouds.blobstore.options.*;
+import org.jclouds.blobstore.util.ForwardingBlobStore;
+import org.jclouds.domain.Location;
+import org.jclouds.io.ContentMetadata;
+import org.jclouds.io.Payload;
+import org.jclouds.io.payloads.InputStreamPayload;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public final class LatencyBlobStore extends ForwardingBlobStore {
+    private static final Pattern PROPERTIES_LATENCY_RE = Pattern.compile(
+            "^" + S3ProxyConstants.PROPERTY_LATENCY + "\\.(?<op>.*)\\.latency$");
+    private static final Pattern PROPERTIES_SPEED_RE = Pattern.compile(
+            "^" + S3ProxyConstants.PROPERTY_LATENCY + "\\.(?<op>.*)\\.speed$");
+    private static final String OP_ALL = "*";
+    private static final String OP_CONTAINER_EXISTS = "container-exists";
+    private static final String OP_CREATE_CONTAINER = "create-container";
+    private static final String OP_CONTAINER_ACCESS = "container-access";
+    private static final String OP_LIST = "list";
+    private static final String OP_CLEAR_CONTAINER = "clear-container";
+    private static final String OP_DELETE_CONTAINER = "delete-container";
+    private static final String OP_DIRECTORY_EXISTS = "directory-exists";
+    private static final String OP_CREATE_DIRECTORY = "create-directory";
+    private static final String OP_DELETE_DIRECTORY = "delete-directory";
+    private static final String OP_BLOB_EXISTS = "blob-exists";
+    private static final String OP_PUT_BLOB = "put";
+    private static final String OP_COPY_BLOB = "copy";
+    private static final String OP_BLOB_METADATA = "metadata";
+    private static final String OP_GET_BLOB = "get";
+    private static final String OP_REMOVE_BLOB = "remove";
+    private static final String OP_BLOB_ACCESS = "blob-access";
+    private static final String OP_COUNT_BLOBS = "count";
+    private static final String OP_MULTIPART_MESSAGE = "multipart-message";
+    private static final String OP_UPLOAD_PART = "upload-part";
+    private static final String OP_LIST_MULTIPART = "list-multipart";
+    private static final String OP_MULTIPART_PARAM = "multipart-param";
+    private static final String OP_DOWNLOAD_BLOB = "download";
+    private static final String OP_STREAM_BLOB = "stream";
+    private final Map<String, Long> latencies;
+    private final Map<String, Long> speeds;
+
+    private LatencyBlobStore(BlobStore blobStore, Map<String, Long> latencies, Map<String, Long> speeds) {
+        super(blobStore);
+        this.latencies = requireNonNull(latencies);
+        for (String op : latencies.keySet()) {
+            checkArgument(latencies.get(op) >= 0, "Latency must be non negative for %s", op);
+        }
+        this.speeds = requireNonNull(speeds);
+        for (String op : speeds.keySet()) {
+            checkArgument(speeds.get(op) > 0, "Speed must be positive for %s", op);
+        }
+    }
+
+    public static Map<String, Long> parseLatencies(Properties properties) {
+        var latencies = new ImmutableMap.Builder<String, Long>();
+        for (String key : properties.stringPropertyNames()) {
+            Matcher matcher = PROPERTIES_LATENCY_RE.matcher(key);
+            if (!matcher.matches()) {
+                continue;
+            }
+            String op = matcher.group("op");
+            long latency = Long.parseLong(properties.getProperty(key));
+            checkArgument(latency >= 0, "Latency must be non negative for %s", op);
+            latencies.put(op, latency);
+        }
+        return latencies.build();
+    }
+
+    public static Map<String, Long> parseSpeeds(Properties properties) {
+        var speeds = new ImmutableMap.Builder<String, Long>();
+        for (String key : properties.stringPropertyNames()) {
+            Matcher matcher = PROPERTIES_SPEED_RE.matcher(key);
+            if (!matcher.matches()) {
+                continue;
+            }
+            String op = matcher.group("op");
+            long speed = Long.parseLong(properties.getProperty(key));
+            checkArgument(speed > 0, "Speed must be positive for %s", op);
+            speeds.put(op, speed);
+        }
+        return speeds.build();
+    }
+
+    static BlobStore newLatencyBlobStore(BlobStore delegate, Map<String, Long> latencies, Map<String, Long> speeds) {
+        return new LatencyBlobStore(delegate, latencies, speeds);
+    }
+
+    @Override
+    public Set<? extends Location> listAssignableLocations() {
+        simulateLatency(OP_LIST);
+        return super.listAssignableLocations();
+    }
+
+    @Override
+    public PageSet<? extends StorageMetadata> list() {
+        simulateLatency(OP_LIST);
+        return super.list();
+    }
+
+    @Override
+    public boolean containerExists(String container) {
+        simulateLatency(OP_CONTAINER_EXISTS);
+        return super.containerExists(container);
+    }
+
+    @Override
+    public boolean createContainerInLocation(Location location, String container) {
+        simulateLatency(OP_CREATE_CONTAINER);
+        return super.createContainerInLocation(location, container);
+    }
+
+    @Override
+    public boolean createContainerInLocation(Location location, String container, CreateContainerOptions createContainerOptions) {
+        simulateLatency(OP_CREATE_CONTAINER);
+        return super.createContainerInLocation(location, container, createContainerOptions);
+    }
+
+    @Override
+    public ContainerAccess getContainerAccess(String container) {
+        simulateLatency(OP_CONTAINER_ACCESS);
+        return super.getContainerAccess(container);
+    }
+
+    @Override
+    public void setContainerAccess(String container, ContainerAccess containerAccess) {
+        simulateLatency(OP_CONTAINER_ACCESS);
+        super.setContainerAccess(container, containerAccess);
+    }
+
+    @Override
+    public PageSet<? extends StorageMetadata> list(String container) {
+        simulateLatency(OP_LIST);
+        return super.list(container);
+    }
+
+    @Override
+    public PageSet<? extends StorageMetadata> list(String container, ListContainerOptions options) {
+        simulateLatency(OP_LIST);
+        return super.list(container, options);
+    }
+
+    @Override
+    public void clearContainer(String container) {
+        simulateLatency(OP_CLEAR_CONTAINER);
+        super.clearContainer(container);
+    }
+
+    @Override
+    public void clearContainer(String container, ListContainerOptions options) {
+        simulateLatency(OP_CLEAR_CONTAINER);
+        super.clearContainer(container, options);
+    }
+
+    @Override
+    public void deleteContainer(String container) {
+        simulateLatency(OP_DELETE_CONTAINER);
+        super.deleteContainer(container);
+    }
+
+    @Override
+    public boolean deleteContainerIfEmpty(String container) {
+        simulateLatency(OP_DELETE_CONTAINER);
+        return super.deleteContainerIfEmpty(container);
+    }
+
+    @Override
+    public boolean directoryExists(String container, String directory) {
+        simulateLatency(OP_DIRECTORY_EXISTS);
+        return super.directoryExists(container, directory);
+    }
+
+    @Override
+    public void createDirectory(String container, String directory) {
+        simulateLatency(OP_CREATE_DIRECTORY);
+        super.createDirectory(container, directory);
+    }
+
+    @Override
+    public void deleteDirectory(String container, String directory) {
+        simulateLatency(OP_DELETE_DIRECTORY);
+        super.deleteDirectory(container, directory);
+    }
+
+    @Override
+    public boolean blobExists(String container, String name) {
+        simulateLatency(OP_BLOB_EXISTS);
+        return super.blobExists(container, name);
+    }
+
+    @Override
+    public String putBlob(String containerName, Blob blob) {
+        simulateLatency(OP_PUT_BLOB);
+        try {
+            InputStream is = blob.getPayload().openStream();
+            Blob newBlob = replaceStream(blob, new ThrottledInputStream(is, getSpeed(OP_PUT_BLOB)));
+            return super.putBlob(containerName, newBlob);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public String putBlob(String containerName, Blob blob, PutOptions putOptions) {
+        simulateLatency(OP_PUT_BLOB);
+        try {
+            InputStream is = blob.getPayload().openStream();
+            Blob newBlob = replaceStream(blob, new ThrottledInputStream(is, getSpeed(OP_PUT_BLOB)));
+            return super.putBlob(containerName, newBlob);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public String copyBlob(String fromContainer, String fromName, String toContainer, String toName, CopyOptions options) {
+        simulateLatency(OP_COPY_BLOB);
+        return super.copyBlob(fromContainer, fromName, toContainer, toName, options);
+    }
+
+    @Override
+    public BlobMetadata blobMetadata(String container, String name) {
+        simulateLatency(OP_BLOB_METADATA);
+        return super.blobMetadata(container, name);
+    }
+
+    @Override
+    public Blob getBlob(String containerName, String blobName) {
+        simulateLatency(OP_GET_BLOB);
+        Blob blob = super.getBlob(containerName, blobName);
+        try {
+            InputStream is = blob.getPayload().openStream();
+            return replaceStream(blob, new ThrottledInputStream(is, getSpeed(OP_GET_BLOB)));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public Blob getBlob(String containerName, String blobName, GetOptions getOptions) {
+        simulateLatency(OP_GET_BLOB);
+        Blob blob = super.getBlob(containerName, blobName, getOptions);
+        try {
+            InputStream is = blob.getPayload().openStream();
+            return replaceStream(blob, new ThrottledInputStream(is, getSpeed(OP_GET_BLOB)));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void removeBlob(String container, String name) {
+        simulateLatency(OP_REMOVE_BLOB);
+        super.removeBlob(container, name);
+    }
+
+    @Override
+    public void removeBlobs(String container, Iterable<String> iterable) {
+        simulateLatency(OP_REMOVE_BLOB);
+        super.removeBlobs(container, iterable);
+    }
+
+    @Override
+    public BlobAccess getBlobAccess(String container, String name) {
+        simulateLatency(OP_BLOB_ACCESS);
+        return super.getBlobAccess(container, name);
+    }
+
+    @Override
+    public void setBlobAccess(String container, String name, BlobAccess access) {
+        simulateLatency(OP_BLOB_ACCESS);
+        super.setBlobAccess(container, name, access);
+    }
+
+    @Override
+    public long countBlobs(String container) {
+        simulateLatency(OP_COUNT_BLOBS);
+        return super.countBlobs(container);
+    }
+
+    @Override
+    public long countBlobs(String container, ListContainerOptions options) {
+        simulateLatency(OP_COUNT_BLOBS);
+        return super.countBlobs(container, options);
+    }
+
+    @Override
+    public MultipartUpload initiateMultipartUpload(String container, BlobMetadata blobMetadata, PutOptions options) {
+        simulateLatency(OP_MULTIPART_MESSAGE);
+        return super.initiateMultipartUpload(container, blobMetadata, options);
+    }
+
+    @Override
+    public void abortMultipartUpload(MultipartUpload mpu) {
+        simulateLatency(OP_MULTIPART_MESSAGE);
+        super.abortMultipartUpload(mpu);
+    }
+
+    @Override
+    public String completeMultipartUpload(MultipartUpload mpu, List<MultipartPart> parts) {
+        simulateLatency(OP_MULTIPART_MESSAGE);
+        return super.completeMultipartUpload(mpu, parts);
+    }
+
+    @Override
+    public MultipartPart uploadMultipartPart(MultipartUpload mpu, int partNumber, Payload payload) {
+        simulateLatency(OP_UPLOAD_PART);
+        try {
+            InputStream is = payload.openStream();
+            payload = new InputStreamPayload(new ThrottledInputStream(is, getSpeed(OP_UPLOAD_PART)));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return super.uploadMultipartPart(mpu, partNumber, payload);
+    }
+
+    @Override
+    public List<MultipartPart> listMultipartUpload(MultipartUpload mpu) {
+        simulateLatency(OP_LIST_MULTIPART);
+        return super.listMultipartUpload(mpu);
+    }
+
+    @Override
+    public List<MultipartUpload> listMultipartUploads(String container) {
+        simulateLatency(OP_LIST_MULTIPART);
+        return super.listMultipartUploads(container);
+    }
+
+    @Override
+    public long getMinimumMultipartPartSize() {
+        simulateLatency(OP_MULTIPART_PARAM);
+        return super.getMinimumMultipartPartSize();
+    }
+
+    @Override
+    public long getMaximumMultipartPartSize() {
+        simulateLatency(OP_MULTIPART_PARAM);
+        return super.getMaximumMultipartPartSize();
+    }
+
+    @Override
+    public int getMaximumNumberOfParts() {
+        simulateLatency(OP_MULTIPART_PARAM);
+        return super.getMaximumNumberOfParts();
+    }
+
+    @Override
+    public void downloadBlob(String container, String name, File destination) {
+        simulateLatency(OP_DOWNLOAD_BLOB);
+        super.downloadBlob(container, name, destination);
+    }
+
+    @Override
+    public void downloadBlob(String container, String name, File destination, ExecutorService executor) {
+        simulateLatency(OP_DOWNLOAD_BLOB);
+        super.downloadBlob(container, name, destination, executor);
+    }
+
+    @Override
+    public InputStream streamBlob(String container, String name) {
+        simulateLatency(OP_STREAM_BLOB);
+        InputStream is = super.streamBlob(container, name);
+        return new ThrottledInputStream(is, getSpeed(OP_STREAM_BLOB));
+    }
+
+    @Override
+    public InputStream streamBlob(String container, String name, ExecutorService executor) {
+        simulateLatency(OP_STREAM_BLOB);
+        InputStream is = super.streamBlob(container, name, executor);
+        return new ThrottledInputStream(is, getSpeed(OP_STREAM_BLOB));
+    }
+
+    private long getLatency(String op) {
+        return latencies.getOrDefault(op, latencies.getOrDefault(OP_ALL, 0L));
+    }
+
+    private Long getSpeed(String op) {
+        return speeds.getOrDefault(op, speeds.getOrDefault(OP_ALL, null));
+    }
+
+    private void simulateLatency(String op) {
+        long latency = getLatency(op);
+        if (latency > 0) {
+            try {
+                Thread.sleep(latency);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private Blob replaceStream(Blob blob, InputStream is) {
+        BlobMetadata blobMeta = blob.getMetadata();
+        ContentMetadata contentMeta = blobMeta.getContentMetadata();
+        Map<String, String> userMetadata = blobMeta.getUserMetadata();
+
+        Blob newBlob = blobBuilder(blobMeta.getName())
+                .type(blobMeta.getType())
+                .tier(blobMeta.getTier())
+                .userMetadata(userMetadata)
+                .payload(is)
+                .cacheControl(contentMeta.getCacheControl())
+                .contentDisposition(contentMeta.getContentDisposition())
+                .contentEncoding(contentMeta.getContentEncoding())
+                .contentLanguage(contentMeta.getContentLanguage())
+                .contentLength(contentMeta.getContentLength())
+                .contentType(contentMeta.getContentType())
+                .build();
+
+        newBlob.getMetadata().setUri(blobMeta.getUri());
+        newBlob.getMetadata().setETag(blobMeta.getETag());
+        newBlob.getMetadata().setLastModified(blobMeta.getLastModified());
+        newBlob.getMetadata().setSize(blobMeta.getSize());
+        newBlob.getMetadata().setPublicUri(blobMeta.getPublicUri());
+        newBlob.getMetadata().setContainer(blobMeta.getContainer());
+
+        return newBlob;
+    }
+}

--- a/src/main/java/org/gaul/s3proxy/Main.java
+++ b/src/main/java/org/gaul/s3proxy/Main.java
@@ -307,6 +307,13 @@ public final class Main {
                             blobStore, fromChars, toChars);
         }
 
+        Map<String, Long> latencies = LatencyBlobStore.parseLatencies(properties);
+        Map<String, Long> speeds = LatencyBlobStore.parseSpeeds(properties);
+        if (!latencies.isEmpty() || !speeds.isEmpty()) {
+            System.err.println("Using latency storage backend");
+            blobStore = LatencyBlobStore.newLatencyBlobStore(blobStore, latencies, speeds);
+        }
+
         return blobStore;
     }
 

--- a/src/main/java/org/gaul/s3proxy/S3ProxyConstants.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyConstants.java
@@ -135,6 +135,9 @@ public final class S3ProxyConstants {
     public static final String PROPERTY_USER_METADATA_REPLACER_TO_CHARS =
             "s3proxy.user-metadata-replacer-blobstore.to-chars";
 
+    public static final String PROPERTY_LATENCY =
+            "s3proxy.latency-blobstore";
+
     static final String PROPERTY_ALT_JCLOUDS_PREFIX = "alt.";
 
     private S3ProxyConstants() {

--- a/src/main/java/org/gaul/s3proxy/ThrottledInputStream.java
+++ b/src/main/java/org/gaul/s3proxy/ThrottledInputStream.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2014-2025 Andrew Gaul <andrew@gaul.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gaul.s3proxy;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+final class ThrottledInputStream extends FilterInputStream {
+    private final Long speed;
+
+    ThrottledInputStream(InputStream is, Long speed) {
+        super(is);
+        this.speed = speed;
+    }
+
+    @Override
+    public int read() throws IOException {
+        int b = super.read();
+        if (b != -1) {
+            simulateLatency(1);
+        }
+        return b;
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        int n = super.read(b, off, len);
+        if (n != -1) {
+            simulateLatency(n);
+        }
+        return n;
+    }
+
+    private void simulateLatency(int size) {
+        if (size == 0 || speed == null) {
+            return;
+        }
+        try {
+            Thread.sleep(size / speed, (int) (size % speed) * 1_000_000);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/src/test/java/org/gaul/s3proxy/LatencyBlobStoreTest.java
+++ b/src/test/java/org/gaul/s3proxy/LatencyBlobStoreTest.java
@@ -1,0 +1,300 @@
+/*
+ * Copyright 2014-2025 Andrew Gaul <andrew@gaul.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gaul.s3proxy;
+
+import com.google.common.io.ByteSource;
+import org.jclouds.ContextBuilder;
+import org.jclouds.blobstore.BlobStore;
+import org.jclouds.blobstore.BlobStoreContext;
+import org.jclouds.blobstore.domain.Blob;
+import org.jclouds.io.Payload;
+import org.jclouds.io.Payloads;
+import org.jclouds.logging.slf4j.config.SLF4JLoggingModule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+public final class LatencyBlobStoreTest {
+    private BlobStoreContext context;
+    private BlobStore delegate;
+    private String containerName;
+
+    @Before
+    public void setUp() throws Exception {
+        containerName = createRandomContainerName();
+
+        context = ContextBuilder
+                .newBuilder("transient")
+                .credentials("identity", "credential")
+                .modules(List.of(new SLF4JLoggingModule()))
+                .build(BlobStoreContext.class);
+        delegate = context.getBlobStore();
+        delegate.createContainerInLocation(null, containerName);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (context != null) {
+            delegate.deleteContainer(containerName);
+            context.close();
+        }
+    }
+
+    @Test
+    public void testLoadProperties() throws Exception {
+        String propertiesString = "s3proxy.latency-blobstore.*.latency=1000\n" +
+                "s3proxy.latency-blobstore.put.speed=10";
+        InputStream stream = new ByteArrayInputStream(propertiesString.getBytes());
+        Properties properties = new Properties();
+        properties.load(stream);
+
+        Map<String, Long> latencies = LatencyBlobStore.parseLatencies(properties);
+        Map<String, Long> speeds = LatencyBlobStore.parseSpeeds(properties);
+
+        assertThat(latencies.containsKey("*")).isTrue();
+        assertThat(latencies.get("*")).isEqualTo(1000L);
+        assertThat(speeds.containsKey("put")).isTrue();
+        assertThat(speeds.get("put")).isEqualTo(10);
+        assertThat(speeds.containsKey("*")).isFalse();
+    }
+
+    @Test
+    public void testNoLatency() {
+        BlobStore latencyBlobStore = LatencyBlobStore.newLatencyBlobStore(delegate, Map.ofEntries(), Map.ofEntries());
+
+        long timeTaken = time(() -> latencyBlobStore.containerExists(containerName));
+        assertThat(timeTaken).isLessThan(500L);
+    }
+
+    @Test
+    public void testAllLatency() {
+        BlobStore latencyBlobStore = LatencyBlobStore.newLatencyBlobStore(delegate,
+                Map.ofEntries(Map.entry("*", 1000L)), Map.ofEntries());
+
+        long timeTaken = time(() -> latencyBlobStore.containerExists(containerName));
+        assertThat(timeTaken).isGreaterThanOrEqualTo(1000L);
+        assertThat(timeTaken).isLessThan(1500L);
+    }
+
+    @Test
+    public void testSpecificLatency() {
+        BlobStore latencyBlobStore = LatencyBlobStore.newLatencyBlobStore(delegate,
+                Map.ofEntries(Map.entry("*", 0L),
+                        Map.entry("container-exists", 1000L)), Map.ofEntries());
+
+        long timeTaken = time(() -> latencyBlobStore.containerExists(containerName));
+        assertThat(timeTaken).isGreaterThanOrEqualTo(1000L);
+        assertThat(timeTaken).isLessThan(1500L);
+    }
+
+    @Test
+    public void testNoSpeed() throws Exception {
+        BlobStore latencyBlobStore = LatencyBlobStore.newLatencyBlobStore(delegate, Map.ofEntries(), Map.ofEntries());
+
+        String blobName = createRandomBlobName();
+        ByteSource content = TestUtils.randomByteSource().slice(0, 1024);
+        Payload payload = Payloads.newByteSourcePayload(content);
+        payload.getContentMetadata().setContentLength(content.size());
+        Blob blob = latencyBlobStore.blobBuilder(blobName).payload(payload).build();
+
+        long timeTaken = time(() -> latencyBlobStore.putBlob(containerName, blob));
+        assertThat(timeTaken).isLessThan(500L);
+    }
+
+    @Test
+    public void testNoSpeedWithLargeFile() throws Exception {
+        BlobStore latencyBlobStore = LatencyBlobStore.newLatencyBlobStore(delegate, Map.ofEntries(), Map.ofEntries());
+
+        String blobName = createRandomBlobName();
+        ByteSource content = TestUtils.randomByteSource().slice(0, 4 * 1024 * 1024);
+        Payload payload = Payloads.newByteSourcePayload(content);
+        payload.getContentMetadata().setContentLength(content.size());
+        Blob blob = latencyBlobStore.blobBuilder(blobName).payload(payload).build();
+
+        long timeTaken = time(() -> latencyBlobStore.putBlob(containerName, blob));
+        assertThat(timeTaken).isLessThan(500L);
+    }
+
+    @Test
+    public void testAllSpeed() throws Exception {
+        BlobStore latencyBlobStore = LatencyBlobStore.newLatencyBlobStore(delegate,
+                Map.ofEntries(), Map.ofEntries(Map.entry("*", 1L)));
+
+        String blobName = createRandomBlobName();
+        ByteSource content = TestUtils.randomByteSource().slice(0, 1024);
+        Payload payload = Payloads.newByteSourcePayload(content);
+        payload.getContentMetadata().setContentLength(content.size());
+        Blob blob = latencyBlobStore.blobBuilder(blobName).payload(payload).build();
+
+        long timeTaken = time(() -> latencyBlobStore.putBlob(containerName, blob));
+        assertThat(timeTaken).isGreaterThanOrEqualTo(1000L);
+        assertThat(timeTaken).isLessThan(1500L);
+    }
+
+    @Test
+    public void testSpecificSpeed() throws Exception {
+        BlobStore latencyBlobStore = LatencyBlobStore.newLatencyBlobStore(delegate,
+                Map.ofEntries(), Map.ofEntries(Map.entry("*", 1000L),
+                        Map.entry("put", 1L)));
+
+        String blobName = createRandomBlobName();
+        ByteSource content = TestUtils.randomByteSource().slice(0, 1024);
+        Payload payload = Payloads.newByteSourcePayload(content);
+        payload.getContentMetadata().setContentLength(content.size());
+        Blob blob = latencyBlobStore.blobBuilder(blobName).payload(payload).build();
+
+        long timeTaken = time(() -> latencyBlobStore.putBlob(containerName, blob));
+        assertThat(timeTaken).isGreaterThanOrEqualTo(1000L);
+        assertThat(timeTaken).isLessThan(1500L);
+    }
+
+    @Test
+    public void testInvalidLatency() {
+        assertThatIllegalArgumentException().isThrownBy(() -> LatencyBlobStore.newLatencyBlobStore(delegate,
+                Map.ofEntries(Map.entry("*", -1000L)), Map.ofEntries()));
+    }
+
+    @Test
+    public void testInvalidSpeed() {
+        assertThatIllegalArgumentException().isThrownBy(() -> LatencyBlobStore.newLatencyBlobStore(delegate,
+                Map.ofEntries(), Map.ofEntries(Map.entry("*", 0L))));
+        assertThatIllegalArgumentException().isThrownBy(() -> LatencyBlobStore.newLatencyBlobStore(delegate,
+                Map.ofEntries(), Map.ofEntries(Map.entry("*", -1000L))));
+    }
+
+    @Test
+    public void testLatencyAndSpeed() throws Exception {
+        BlobStore latencyBlobStore = LatencyBlobStore.newLatencyBlobStore(delegate,
+                Map.ofEntries(Map.entry("*", 1000L)), Map.ofEntries(Map.entry("put", 1L)));
+
+        String blobName = createRandomBlobName();
+        ByteSource content = TestUtils.randomByteSource().slice(0, 1024);
+        Payload payload = Payloads.newByteSourcePayload(content);
+        payload.getContentMetadata().setContentLength(content.size());
+        Blob blob = latencyBlobStore.blobBuilder(blobName).payload(payload).build();
+
+        long timeTaken = time(() -> latencyBlobStore.putBlob(containerName, blob));
+        assertThat(timeTaken).isGreaterThanOrEqualTo(2000L);
+        assertThat(timeTaken).isLessThan(2500L);
+    }
+
+    @Test
+    public void testLatencyAndSpeedWithEmptyContent() throws Exception {
+        BlobStore latencyBlobStore = LatencyBlobStore.newLatencyBlobStore(delegate,
+                Map.ofEntries(Map.entry("put", 1000L)), Map.ofEntries(Map.entry("put", 1L)));
+
+        String blobName = createRandomBlobName();
+        ByteSource content = TestUtils.randomByteSource().slice(0, 0);
+        Payload payload = Payloads.newByteSourcePayload(content);
+        payload.getContentMetadata().setContentLength(content.size());
+        Blob blob = latencyBlobStore.blobBuilder(blobName).payload(payload).build();
+
+        long timeTaken = time(() -> latencyBlobStore.putBlob(containerName, blob));
+        assertThat(timeTaken).isGreaterThanOrEqualTo(1000L);
+        assertThat(timeTaken).isLessThan(1500L);
+    }
+
+    @Test
+    public void testMultipleOperations() throws Exception {
+        BlobStore latencyBlobStore = LatencyBlobStore.newLatencyBlobStore(delegate,
+                Map.ofEntries(Map.entry("*", 1000L)), Map.ofEntries(Map.entry("get", 1L)));
+
+        String blobName = createRandomBlobName();
+        ByteSource content = TestUtils.randomByteSource().slice(0, 1024);
+        Payload payload = Payloads.newByteSourcePayload(content);
+        payload.getContentMetadata().setContentLength(content.size());
+        Blob blob = latencyBlobStore.blobBuilder(blobName).payload(payload).build();
+
+        long timeTaken = time(() -> {
+            latencyBlobStore.putBlob(containerName, blob);
+            consume(latencyBlobStore.getBlob(containerName, blobName));
+        });
+        assertThat(timeTaken).isGreaterThanOrEqualTo(3000L);
+        assertThat(timeTaken).isLessThan(3500L);
+    }
+
+    @Test
+    public void testSimultaneousOperations() throws Exception {
+        BlobStore latencyBlobStore = LatencyBlobStore.newLatencyBlobStore(delegate,
+                Map.ofEntries(Map.entry("*", 1000L)), Map.ofEntries(Map.entry("get", 1L)));
+
+        String blobName = createRandomBlobName();
+        ByteSource content = TestUtils.randomByteSource().slice(0, 1024);
+        Payload payload = Payloads.newByteSourcePayload(content);
+        payload.getContentMetadata().setContentLength(content.size());
+        Blob blob = latencyBlobStore.blobBuilder(blobName).payload(payload).build();
+        latencyBlobStore.putBlob(containerName, blob);
+
+        ExecutorService executorService = null;
+        try {
+            executorService = Executors.newFixedThreadPool(5);
+
+            List<Callable<Object>> tasks = new ArrayList<>();
+            for (int i = 0; i < 5; i++) {
+                tasks.add(Executors.callable(() -> consume(latencyBlobStore.getBlob(containerName, blobName))));
+            }
+
+            final ExecutorService service = executorService;
+            long timeTaken = time(() -> {
+                try {
+                    service.invokeAll(tasks);
+                } catch (Exception e) {
+                    // Ignore
+                }
+            });
+            assertThat(timeTaken).isGreaterThanOrEqualTo(2000L);
+            assertThat(timeTaken).isLessThan(2500L);
+        } finally {
+            if (executorService != null) {
+                executorService.shutdown();
+            }
+        }
+    }
+
+    private static String createRandomContainerName() {
+        return "container-" + new Random().nextInt(Integer.MAX_VALUE);
+    }
+
+    private static String createRandomBlobName() {
+        return "blob-" + new Random().nextInt(Integer.MAX_VALUE);
+    }
+
+    private static long time(Runnable runnable) {
+        long startTime = System.currentTimeMillis();
+        runnable.run();
+        return System.currentTimeMillis() - startTime;
+    }
+
+    private static void consume(Blob blob) {
+        try (InputStream stream = blob.getPayload().openStream()) {
+            stream.readAllBytes();
+        } catch (IOException ioe) {
+            // Ignore
+        }
+    }
+}

--- a/src/test/java/org/gaul/s3proxy/LatencyBlobStoreTest.java
+++ b/src/test/java/org/gaul/s3proxy/LatencyBlobStoreTest.java
@@ -16,7 +16,23 @@
 
 package org.gaul.s3proxy;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Random;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
 import com.google.common.io.ByteSource;
+
+import org.assertj.core.api.Assertions;
 import org.jclouds.ContextBuilder;
 import org.jclouds.blobstore.BlobStore;
 import org.jclouds.blobstore.BlobStoreContext;
@@ -27,17 +43,6 @@ import org.jclouds.logging.slf4j.config.SLF4JLoggingModule;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.*;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 public final class LatencyBlobStoreTest {
     private BlobStoreContext context;
@@ -135,15 +140,15 @@ public final class LatencyBlobStoreTest {
 
     @Test
     public void testInvalidLatency() {
-        assertThatIllegalArgumentException().isThrownBy(() -> LatencyBlobStore.newLatencyBlobStore(delegate,
+        Assertions.assertThatIllegalArgumentException().isThrownBy(() -> LatencyBlobStore.newLatencyBlobStore(delegate,
                 Map.ofEntries(Map.entry("*", -1000L)), Map.ofEntries()));
     }
 
     @Test
     public void testInvalidSpeed() {
-        assertThatIllegalArgumentException().isThrownBy(() -> LatencyBlobStore.newLatencyBlobStore(delegate,
+        Assertions.assertThatIllegalArgumentException().isThrownBy(() -> LatencyBlobStore.newLatencyBlobStore(delegate,
                 Map.ofEntries(), Map.ofEntries(Map.entry("*", 0L))));
-        assertThatIllegalArgumentException().isThrownBy(() -> LatencyBlobStore.newLatencyBlobStore(delegate,
+        Assertions.assertThatIllegalArgumentException().isThrownBy(() -> LatencyBlobStore.newLatencyBlobStore(delegate,
                 Map.ofEntries(), Map.ofEntries(Map.entry("*", -1000L))));
     }
 

--- a/src/test/java/org/gaul/s3proxy/LatencyBlobStoreTest.java
+++ b/src/test/java/org/gaul/s3proxy/LatencyBlobStoreTest.java
@@ -84,21 +84,12 @@ public final class LatencyBlobStoreTest {
     }
 
     @Test
-    public void testNoLatency() {
-        BlobStore latencyBlobStore = LatencyBlobStore.newLatencyBlobStore(delegate, Map.ofEntries(), Map.ofEntries());
-
-        long timeTaken = time(() -> latencyBlobStore.containerExists(containerName));
-        assertThat(timeTaken).isLessThan(500L);
-    }
-
-    @Test
     public void testAllLatency() {
         BlobStore latencyBlobStore = LatencyBlobStore.newLatencyBlobStore(delegate,
                 Map.ofEntries(Map.entry("*", 1000L)), Map.ofEntries());
 
         long timeTaken = time(() -> latencyBlobStore.containerExists(containerName));
         assertThat(timeTaken).isGreaterThanOrEqualTo(1000L);
-        assertThat(timeTaken).isLessThan(1500L);
     }
 
     @Test
@@ -109,35 +100,6 @@ public final class LatencyBlobStoreTest {
 
         long timeTaken = time(() -> latencyBlobStore.containerExists(containerName));
         assertThat(timeTaken).isGreaterThanOrEqualTo(1000L);
-        assertThat(timeTaken).isLessThan(1500L);
-    }
-
-    @Test
-    public void testNoSpeed() throws Exception {
-        BlobStore latencyBlobStore = LatencyBlobStore.newLatencyBlobStore(delegate, Map.ofEntries(), Map.ofEntries());
-
-        String blobName = createRandomBlobName();
-        ByteSource content = TestUtils.randomByteSource().slice(0, 1024);
-        Payload payload = Payloads.newByteSourcePayload(content);
-        payload.getContentMetadata().setContentLength(content.size());
-        Blob blob = latencyBlobStore.blobBuilder(blobName).payload(payload).build();
-
-        long timeTaken = time(() -> latencyBlobStore.putBlob(containerName, blob));
-        assertThat(timeTaken).isLessThan(500L);
-    }
-
-    @Test
-    public void testNoSpeedWithLargeFile() throws Exception {
-        BlobStore latencyBlobStore = LatencyBlobStore.newLatencyBlobStore(delegate, Map.ofEntries(), Map.ofEntries());
-
-        String blobName = createRandomBlobName();
-        ByteSource content = TestUtils.randomByteSource().slice(0, 4 * 1024 * 1024);
-        Payload payload = Payloads.newByteSourcePayload(content);
-        payload.getContentMetadata().setContentLength(content.size());
-        Blob blob = latencyBlobStore.blobBuilder(blobName).payload(payload).build();
-
-        long timeTaken = time(() -> latencyBlobStore.putBlob(containerName, blob));
-        assertThat(timeTaken).isLessThan(500L);
     }
 
     @Test
@@ -153,7 +115,6 @@ public final class LatencyBlobStoreTest {
 
         long timeTaken = time(() -> latencyBlobStore.putBlob(containerName, blob));
         assertThat(timeTaken).isGreaterThanOrEqualTo(1000L);
-        assertThat(timeTaken).isLessThan(1500L);
     }
 
     @Test
@@ -170,7 +131,6 @@ public final class LatencyBlobStoreTest {
 
         long timeTaken = time(() -> latencyBlobStore.putBlob(containerName, blob));
         assertThat(timeTaken).isGreaterThanOrEqualTo(1000L);
-        assertThat(timeTaken).isLessThan(1500L);
     }
 
     @Test
@@ -200,7 +160,6 @@ public final class LatencyBlobStoreTest {
 
         long timeTaken = time(() -> latencyBlobStore.putBlob(containerName, blob));
         assertThat(timeTaken).isGreaterThanOrEqualTo(2000L);
-        assertThat(timeTaken).isLessThan(2500L);
     }
 
     @Test
@@ -216,7 +175,6 @@ public final class LatencyBlobStoreTest {
 
         long timeTaken = time(() -> latencyBlobStore.putBlob(containerName, blob));
         assertThat(timeTaken).isGreaterThanOrEqualTo(1000L);
-        assertThat(timeTaken).isLessThan(1500L);
     }
 
     @Test
@@ -235,7 +193,6 @@ public final class LatencyBlobStoreTest {
             consume(latencyBlobStore.getBlob(containerName, blobName));
         });
         assertThat(timeTaken).isGreaterThanOrEqualTo(3000L);
-        assertThat(timeTaken).isLessThan(3500L);
     }
 
     @Test
@@ -268,7 +225,6 @@ public final class LatencyBlobStoreTest {
                 }
             });
             assertThat(timeTaken).isGreaterThanOrEqualTo(2000L);
-            assertThat(timeTaken).isLessThan(2500L);
         } finally {
             if (executorService != null) {
                 executorService.shutdown();


### PR DESCRIPTION
Allows running performance tests with s3proxy using simulated latency and read/write speed
- Added LatencyBlobStore, ThrottledInputStream
- Parse properties from s3proxy.conf
```
s3proxy.latency-blobstore.*.latency=1000 # Add 1000ms latency to all operations
s3proxy.latency-blobstore.put.latency=2000 # Override put blob to 2000ms latency
s3proxy.latency-blobstore.put.speed=10 # Limit put blob to 10 kb/s
```