### PR TITLE
Force Jetty header cache to be case-sensitive, to avoid signature mismatch

### DIFF
--- a/src/main/java/org/gaul/s3proxy/S3Proxy.java
+++ b/src/main/java/org/gaul/s3proxy/S3Proxy.java
@@ -92,6 +92,8 @@ public final class S3Proxy {
         var httpConfiguration = new HttpConfiguration();
         httpConfiguration.setHttpCompliance(HttpCompliance.LEGACY);
         httpConfiguration.setUriCompliance(UriCompliance.LEGACY);
+        httpConfiguration.setHeaderCacheCaseSensitive(true);
+
         var src = new SecureRequestCustomizer();
         src.setSniHostCheck(false);
         httpConfiguration.addCustomizer(src);


### PR DESCRIPTION
Jetty's header cache sometimes results in headers (and their values) being changed from what is sent in the request due to it's case insensitive nature.

This breaks AWS V2 and V4 signature calculations, as the sender will have calculated the signature with slightly different values.

E.g.

1. Charset is 'utf-8' when calculating the signature and sent across in the headers as 'utf-8'
2. Jetty's cache results in this becoming 'UTF-8' at S3Proxy
3. S3Proxy then uses 'UTF-8' when calculating the signature.
4. Signature mismatch then occurs

Forcing the cache to be case sensitive fixes this. Looks like this was an issue in the past, and was fixed by using the LEGACY validation option. However seems to now require this additional setting, which might be caused by the upgrade to Jetty 11?
(Jetty 12 has further work on this, so might need reviewing if/when that upgrade happens).
