### PR TITLE
Upgrade Surefire to 3.5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -370,7 +370,7 @@
     <modernizer.version>3.1.0</modernizer.version>
     <slf4j.version>2.0.17</slf4j.version>
     <shade.prefix>${project.groupId}.shaded</shade.prefix>
-    <surefire.version>3.2.5</surefire.version>
+    <surefire.version>3.5.2</surefire.version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
3.5.3 seems to have a junit incompatibility.  References #819.