### PR TITLE
Fix EncryptedBlobStore error handling

### DIFF
--- a/src/main/java/org/gaul/s3proxy/EncryptedBlobStore.java
+++ b/src/main/java/org/gaul/s3proxy/EncryptedBlobStore.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
 import java.security.spec.KeySpec;
 import java.util.ArrayList;
 import java.util.List;
@@ -104,7 +105,7 @@ public final class EncryptedBlobStore extends ForwardingBlobStore {
                     128);
             SecretKey tmp = factory.generateSecret(spec);
             secretKey = new SecretKeySpec(tmp.getEncoded(), "AES");
-        } catch (Exception e) {
+        } catch (GeneralSecurityException e) {
             throw new IllegalArgumentException(e);
         }
     }
@@ -172,7 +173,7 @@ public final class EncryptedBlobStore extends ForwardingBlobStore {
                     Constants.PADDING_BLOCK_SIZE;
 
             return cipheredBlob(container, blob, is, contentLength, true);
-        } catch (Exception e) {
+        } catch (IOException | GeneralSecurityException e) {
             throw new RuntimeException(e);
         }
     }
@@ -203,7 +204,7 @@ public final class EncryptedBlobStore extends ForwardingBlobStore {
                 .setContentLength(contentLength);
 
             return cipheredPayload;
-        } catch (Exception e) {
+        } catch (IOException | GeneralSecurityException e) {
             throw new RuntimeException(e);
         }
     }
@@ -228,8 +229,8 @@ public final class EncryptedBlobStore extends ForwardingBlobStore {
             }
 
             return cipheredBlob(container, blob, is, contentLength, false);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
         }
     }
 
@@ -444,8 +445,8 @@ public final class EncryptedBlobStore extends ForwardingBlobStore {
                 return delegate().getBlob(containerName, blobName, getOptions);
             }
 
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
         }
     }
 

--- a/src/main/java/org/gaul/s3proxy/crypto/Encryption.java
+++ b/src/main/java/org/gaul/s3proxy/crypto/Encryption.java
@@ -18,6 +18,7 @@ package org.gaul.s3proxy.crypto;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.security.GeneralSecurityException;
 import java.security.SecureRandom;
 
 import javax.annotation.concurrent.ThreadSafe;
@@ -33,7 +34,7 @@ public class Encryption {
     private final int part;
 
     public Encryption(SecretKeySpec key, InputStream isRaw, int partNumber)
-            throws Exception {
+            throws GeneralSecurityException {
         iv = generateIV();
 
         Cipher cipher = Cipher.getInstance(Constants.AES_CIPHER);


### PR DESCRIPTION
Fix for https://github.com/gaul/s3proxy/issues/848

The exceptions caught in `EncryptedBlobStore` were too broad, so that the jclouds `HttpResponseException` was not proxied to the client e.g. in a HTTP 304 conditional request response case.

Refactored the catch blocks to catch only the more specific exceptions related to the actual encryption.

The general `S3ProxyHandlerJetty` handler then handles the others:
https://github.com/gaul/s3proxy/blob/master/src/main/java/org/gaul/s3proxy/S3ProxyHandlerJetty.java#L88