### PR TITLE
Fix azureblob multipart upload regression

### DIFF
--- a/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
@@ -2373,8 +2373,11 @@ public class S3ProxyHandler {
 
         final List<MultipartPart> parts = new ArrayList<>();
         String blobStoreType = getBlobStoreType(blobStore);
-        if (blobStoreType.equals("azureblob") ||
-                blobStoreType.equals("azureblob-sdk")) {
+        if (blobStoreType.equals("azureblob")) {
+            for (MultipartPart part : blobStore.listMultipartUpload(mpu)) {
+                parts.add(part);
+            }
+        } else if (blobStoreType.equals("azureblob-sdk")) {
             var partsByListing =
                 blobStore.listMultipartUpload(mpu).stream().collect(
                         Collectors.toMap(
@@ -2585,8 +2588,7 @@ public class S3ProxyHandler {
 
         List<MultipartPart> parts;
         var blobStoreType = getBlobStoreType(blobStore);
-        if (blobStoreType.equals("azureblob") ||
-                blobStoreType.equals("azureblob-sdk")) {
+        if (blobStoreType.equals("azureblob")) {
             // map Azure subparts back into S3 parts
             SortedMap<Integer, Long> map = new TreeMap<>();
             for (MultipartPart part : blobStore.listMultipartUpload(mpu)) {


### PR DESCRIPTION
## Summary

- Restore `azureblob` provider multipart upload behavior to pre-2.9.0 logic, fixes https://github.com/gaul/s3proxy/issues/929

## Problem

The `azureblob-sdk` multipart upload implementation (commit fb96699) broke the legacy `azureblob` provider by validating part numbers against the client's CompleteMultipartUpload XML request.

The `azureblob` provider uses synthetic part numbers (`10_000 * partNumber + subPartNumber`) to split large S3 parts into smaller Azure blocks. When the new validation logic looked up client-provided part numbers (1, 2, 3...) in a map containing Azure block numbers (10000, 10001...), no match was found, causing `INVALID_PART` errors.

## Changes

- `handleCompleteMultipartUpload`: Restore `azureblob` to its original simple iteration logic; `azureblob-sdk` retains the new XML parsing + validation path
- `handleListParts`: Scope the `/10_000` part-number aggregation to `azureblob` only, allowing `azureblob-sdk` to use direct part numbers. This bug did not surface yet because usually this is not used.

This ensures the new `azureblob-sdk` implementation does not affect the deprecated `azureblob` provider and the `azureblob` part-number magic does not affect the new `azureblob-sdk` provider.

