### PR TITLE
Add new configuration parameter "s3proxy.jetty.idle-timeout" to s3 pr…

### DIFF
--- a/src/main/java/org/gaul/s3proxy/S3Proxy.java
+++ b/src/main/java/org/gaul/s3proxy/S3Proxy.java
@@ -83,6 +83,7 @@ public final class S3Proxy {
                 "Must provide both identity and credential");
 
         var pool = new QueuedThreadPool(builder.jettyMaxThreads);
+        pool.setIdleTimeout(builder.jettyIdleTimeout);
         pool.setName("S3Proxy-Jetty");
         server = new Server(pool);
 
@@ -172,6 +173,7 @@ public final class S3Proxy {
         private boolean ignoreUnknownHeaders;
         private CrossOriginResourceSharing corsRules;
         private int jettyMaxThreads = 200;  // sourced from QueuedThreadPool()
+        private int jettyIdleTimeout = 30000; // Default Jetty idle timeout in ms
         private int maximumTimeSkew = 15 * 60;
         private boolean metricsEnabled;
         private int metricsPort = S3ProxyMetrics.DEFAULT_METRICS_PORT;
@@ -334,6 +336,13 @@ public final class S3Proxy {
                 builder.jettyMaxThreads(Integer.parseInt(jettyMaxThreads));
             }
 
+            String jettyIdleTimeout = properties.getProperty(
+                    S3ProxyConstants.PROPERTY_JETTY_IDLE_TIMEOUT);
+            if (jettyIdleTimeout != null) {
+                builder.jettyIdleTimeout(Integer.parseInt(jettyIdleTimeout));
+            }
+
+
             String maximumTimeSkew = properties.getProperty(
                     S3ProxyConstants.PROPERTY_MAXIMUM_TIME_SKEW);
             if (maximumTimeSkew != null && !maximumTimeSkew.trim().isEmpty()) {
@@ -438,6 +447,11 @@ public final class S3Proxy {
 
         public Builder jettyMaxThreads(int jettyMaxThreads) {
             this.jettyMaxThreads = jettyMaxThreads;
+            return this;
+        }
+
+        public Builder jettyIdleTimeout(int jettyIdleTimeout) {
+            this.jettyIdleTimeout = jettyIdleTimeout;
             return this;
         }
 

--- a/src/main/java/org/gaul/s3proxy/S3ProxyConstants.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyConstants.java
@@ -54,6 +54,8 @@ public final class S3ProxyConstants {
             "s3proxy.keystore-password";
     public static final String PROPERTY_JETTY_MAX_THREADS =
             "s3proxy.jetty.max-threads";
+    public static final String PROPERTY_JETTY_IDLE_TIMEOUT =
+            "s3proxy.jetty.idle-timeout";
 
     /** Request attributes. */
     public static final String ATTRIBUTE_QUERY_ENCODING = "queryEncoding";


### PR DESCRIPTION
Add new configuration parameter "s3proxy.jetty.idle-timeout" to s3 project to set the Jetty parameter, keeping the default of 30000 ms. Setting the idle timeout higher than the default value allows clients with a slow/poor connection to do large multipart-uploads without timing out.

I added this forwarding of the  Jetty configuration option to the s3 configuration because my Litestream connection to the S3 proxy kept timing out over poor celluar services. Upping the idle timeout will allow large and efficient multipart uploads on these poor quality connections.  