### PR TITLE
Create a custom JRE for the Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 # Exclude everything from context that is not used by COPY steps in the Dockerfile
 *
 !/target/s3proxy
+!/target/jdeps-modules.txt
 !/src/main/resources/run-docker-container.sh

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -75,6 +75,31 @@ jobs:
       - name: Maven Package
         run: |
           mvn verify -DskipTests
+
+      - name: Build custom JRE with jlink
+        run: |
+          APP_MODULES=$(cat target/jdeps-modules.txt)
+          # Extra modules needed for Maven/Surefire to function on top of the app modules:
+          #   jdk.compiler  – compiles test sources
+          #   jdk.zipfs     – reads JAR/ZIP files
+          #   java.instrument – JVM instrumentation (used by Surefire agents)
+          #   jdk.attach    – JVM Attach API (used by Maven Surefire plugin)
+          EXTRA_MODULES="jdk.compiler,jdk.zipfs,java.instrument,jdk.attach"
+          ALL_MODULES="${APP_MODULES},${EXTRA_MODULES}"
+          jlink \
+            --add-modules "${ALL_MODULES}" \
+            --bind-services \
+            --strip-debug \
+            --no-man-pages \
+            --no-header-files \
+            --compress=2 \
+            --output /opt/custom-jre
+          # Carry over CA certificates so TLS connections to remote blobstores work
+          cp "${JAVA_HOME}/lib/security/cacerts" /opt/custom-jre/lib/security/cacerts
+          # Override JAVA_HOME and PATH for all subsequent steps in this job
+          echo "JAVA_HOME=/opt/custom-jre" >> $GITHUB_ENV
+          echo "/opt/custom-jre/bin" >> $GITHUB_PATH
+
       - name: Maven Test
         run: |
           mvn test
@@ -101,6 +126,14 @@ jobs:
         with:
           name: s3proxy
           path: target/s3proxy
+      - uses: actions/upload-artifact@v7
+        with:
+          name: s3proxy-jar
+          path: target/s3proxy-*-jar-with-dependencies.jar
+      - uses: actions/upload-artifact@v7
+        with:
+          name: jdeps-modules
+          path: target/jdeps-modules.txt
       - uses: actions/upload-artifact@v7
         with:
           name: pom
@@ -254,6 +287,14 @@ jobs:
           name: s3proxy
           path: target
       - uses: actions/download-artifact@v8
+        with:
+          name: s3proxy-jar
+          path: target
+      - uses: actions/download-artifact@v7
+        with:
+          name: jdeps-modules
+          path: target
+      - uses: actions/download-artifact@v7
         with:
           name: pom
           path: .

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "activityBar.activeBackground": "#ecae34",
+        "activityBar.background": "#ecae34",
+        "activityBar.foreground": "#15202b",
+        "activityBar.inactiveForeground": "#15202b99",
+        "activityBarBadge.background": "#0e9265",
+        "activityBarBadge.foreground": "#e7e7e7",
+        "commandCenter.border": "#15202b99",
+        "sash.hoverBorder": "#ecae34",
+        "statusBar.background": "#d99714",
+        "statusBar.foreground": "#15202b",
+        "statusBarItem.hoverBackground": "#aa7710",
+        "statusBarItem.remoteBackground": "#d99714",
+        "statusBarItem.remoteForeground": "#15202b",
+        "titleBar.activeBackground": "#d99714",
+        "titleBar.activeForeground": "#15202b",
+        "titleBar.inactiveBackground": "#d9971499",
+        "titleBar.inactiveForeground": "#15202b99"
+    },
+    "peacock.remoteColor": "#d99714"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,58 @@
-FROM docker.io/library/eclipse-temurin:21-jre
-LABEL maintainer="Andrew Gaul <andrew@gaul.org>"
+# Stage 1: Create custom JRE with jlink
+FROM docker.io/library/eclipse-temurin:21-jdk AS jre-build
 
 WORKDIR /opt/s3proxy
 
+# Install dumb-init in build stage
 RUN apt-get update && \
     apt-get install -y dumb-init && \
     rm -rf /var/lib/apt/lists/*
 
+# Copy the pre-computed jdeps modules list from the Maven build
+COPY target/jdeps-modules.txt /tmp/modules.txt
+
+# Display the required modules for debugging/verification
+RUN cat /tmp/modules.txt
+
+# Create a custom Java runtime with jlink
+RUN jlink \
+    --add-modules $(cat /tmp/modules.txt) \
+    --bind-services \
+    --strip-debug \
+    --no-man-pages \
+    --no-header-files \
+    --compress=2 \
+    --output /javaruntime
+
+# Copy CA certificates from the source JDK to the custom JRE
+# This is essential for SSL/TLS connections to AWS S3 and other HTTPS endpoints
+RUN cp $JAVA_HOME/lib/security/cacerts /javaruntime/lib/security/cacerts
+
+# Stage 2: Create the final runtime image
+FROM ubuntu:24.04
+LABEL maintainer="Andrew Gaul <andrew@gaul.org>"
+
+# update all packages in the image
+RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opt/s3proxy
+
+# Copy dumb-init from build stage
+COPY --from=jre-build /usr/bin/dumb-init /usr/bin/dumb-init
+
+# Copy custom Java runtime from build stage
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+COPY --from=jre-build /javaruntime $JAVA_HOME
+
+# Copy application files
 COPY \
     target/s3proxy \
     src/main/resources/run-docker-container.sh \
     /opt/s3proxy/
+
+# Ensure the runtime script is executable inside the image
+RUN chmod +x /opt/s3proxy/run-docker-container.sh
 
 ENV \
     LOG_LEVEL="info" \

--- a/pom.xml
+++ b/pom.xml
@@ -409,6 +409,31 @@
           <javaVersion>${java.version}</javaVersion>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.5.0</version>
+        <executions>
+          <execution>
+            <id>jdeps-analysis</id>
+            <phase>package</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <executable>${java.home}/bin/jdeps</executable>
+              <arguments>
+                <argument>--ignore-missing-deps</argument>
+                <argument>--print-module-deps</argument>
+                <argument>--multi-release</argument>
+                <argument>${java.version}</argument>
+                <argument>${project.build.directory}/${project.build.finalName}-jar-with-dependencies.jar</argument>
+              </arguments>
+              <outputFile>${project.build.directory}/jdeps-modules.txt</outputFile>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/src/main/assembly/jar-with-dependencies.xml
+++ b/src/main/assembly/jar-with-dependencies.xml
@@ -21,6 +21,12 @@
       <useProjectArtifact>true</useProjectArtifact>
       <unpack>true</unpack>
       <scope>runtime</scope>
+      <unpackOptions>
+        <excludes>
+          <exclude>**/module-info.class</exclude>
+          <exclude>META-INF/versions/*/module-info.class</exclude>
+        </excludes>
+      </unpackOptions>
     </dependencySet>
   </dependencySets>
   <fileSets>


### PR DESCRIPTION
Fixes #401

Improvement : reduces the attack surfaces on the Docker image (makes our automated tools scream less often).

Custom Java runtime creation:

* Added a Maven `exec-maven-plugin` execution to run `jdeps` during the package phase, outputting the required Java modules to `target/jdeps-modules.txt`. This automates module dependency analysis for `jlink`.
* Updated the `Dockerfile` to use a multi-stage build: the first stage creates a custom JRE with `jlink` using modules listed in `jdeps-modules.txt`, and the second stage builds the final runtime image
* Added comments in the Dockerfile (helps with AI coding assistants)

CI/CD workflow:

* Builds a custom stripped down JRE to run the tests, as close as possible to the one used in the Dockerfile (some extra modules are required by Maven).
* Modified `.github/workflows/ci-main.yml` to upload and download the new `jdeps-modules.txt` and the jar-with-dependencies as build artifacts, ensuring these are available for the Docker build step.
* Updated `.dockerignore` to allow `target/jdeps-modules.txt` into the Docker build context, so the custom JRE can be constructed from actual dependencies.

Build artifact:

* Changed the assembly configuration to exclude `module-info.class` files from the jar-with-dependencies, preventing conflicts and unnecessary files in the runtime.

Docker build : 

- Kept ubuntu as a base for the final image, so as not to break any downstream build