### PR TITLE
Sanitize TARGET_BLOB_NAME_TAG values on Azure

### DIFF
--- a/src/main/java/org/gaul/s3proxy/azureblob/AzureBlobStore.java
+++ b/src/main/java/org/gaul/s3proxy/azureblob/AzureBlobStore.java
@@ -120,6 +120,8 @@ import reactor.core.publisher.Flux;
 public final class AzureBlobStore extends BaseBlobStore {
     private static final String STUB_BLOB_PREFIX = ".s3proxy/stubs/";
     private static final String TARGET_BLOB_NAME_TAG = "s3proxy_target_blob_name";
+    private static final String BASE64URL_PREFIX = "base64url:";
+    private static final String TARGET_BLOB_NAME_MARKER = "s3proxy-v1:";
     private static final HashFunction MD5 = Hashing.md5();
     // Disable retries since client should retry on errors.
     private static final RequestRetryOptions NO_RETRY_OPTIONS = new RequestRetryOptions(
@@ -644,7 +646,8 @@ public final class AzureBlobStore extends BaseBlobStore {
         stubBlobClient.uploadWithResponse(uploadOptions, null, null);
 
         var tags = new java.util.HashMap<String, String>();
-        tags.put(TARGET_BLOB_NAME_TAG, targetBlobName);
+        tags.put(TARGET_BLOB_NAME_TAG,
+                encodeTargetBlobNameTagValue(targetBlobName));
         stubBlobClient.setTags(tags);
 
         return MultipartUpload.create(container, targetBlobName,
@@ -713,7 +716,8 @@ public final class AzureBlobStore extends BaseBlobStore {
             throw bse;
         }
 
-        String targetBlobName = stubTags.get(TARGET_BLOB_NAME_TAG);
+        String targetBlobName = decodeTargetBlobNameTagValue(
+                stubTags.get(TARGET_BLOB_NAME_TAG));
         if (targetBlobName == null) {
             throw new IllegalArgumentException(
                     "Stub blob missing target name tag: uploadId=" + uploadKey);
@@ -977,7 +981,8 @@ public final class AzureBlobStore extends BaseBlobStore {
         String targetBlobName;
         try {
             var stubTags = stubBlobClient.getTags();
-            targetBlobName = stubTags.get(TARGET_BLOB_NAME_TAG);
+            targetBlobName = decodeTargetBlobNameTagValue(
+                    stubTags.get(TARGET_BLOB_NAME_TAG));
         } catch (BlobStorageException bse) {
             if (bse.getErrorCode().equals(BlobErrorCode.BLOB_NOT_FOUND)) {
                 throw new IllegalArgumentException(
@@ -1055,7 +1060,8 @@ public final class AzureBlobStore extends BaseBlobStore {
                 continue;
             }
 
-            String targetBlobName = tags.get(TARGET_BLOB_NAME_TAG);
+            String targetBlobName = decodeTargetBlobNameTagValue(
+                    tags.get(TARGET_BLOB_NAME_TAG));
             builder.add(MultipartUpload.create(container, targetBlobName,
                     uploadKey, null, null));
         }
@@ -1149,6 +1155,33 @@ public final class AzureBlobStore extends BaseBlobStore {
         String rawId = String.format("%s:%05d", nonce, partNumber);
         return Base64.getEncoder().encodeToString(
                 rawId.getBytes(StandardCharsets.UTF_8));
+    }
+
+    static String encodeTargetBlobNameTagValue(String blobName) {
+        String raw = TARGET_BLOB_NAME_MARKER + blobName;
+        return BASE64URL_PREFIX + Base64.getUrlEncoder()
+                .withoutPadding()
+                .encodeToString(raw.getBytes(StandardCharsets.UTF_8));
+    }
+
+    static String decodeTargetBlobNameTagValue(@Nullable String tagValue) {
+        if (tagValue == null || !tagValue.startsWith(BASE64URL_PREFIX)) {
+            return tagValue;
+        }
+        String decodedValue;
+        try {
+            decodedValue = new String(Base64.getUrlDecoder().decode(
+                    tagValue.substring(BASE64URL_PREFIX.length())),
+                    StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException iae) {
+            // Allow legacy/plain values that happen to start with the prefix.
+            return tagValue;
+        }
+        if (!decodedValue.startsWith(TARGET_BLOB_NAME_MARKER)) {
+            // Allow legacy/plain values that decode to arbitrary strings.
+            return tagValue;
+        }
+        return decodedValue.substring(TARGET_BLOB_NAME_MARKER.length());
     }
 
     /**

--- a/src/test/java/org/gaul/s3proxy/azureblob/AzureBlobStoreTest.java
+++ b/src/test/java/org/gaul/s3proxy/azureblob/AzureBlobStoreTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2014-2026 Andrew Gaul <andrew@gaul.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gaul.s3proxy.azureblob;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import org.junit.Test;
+
+public final class AzureBlobStoreTest {
+    @Test
+    public void testTargetBlobNameTagEncodingIsBackwardCompatible() {
+        String blobName = "folder/with spaces/+-_=.txt";
+        String encoded = AzureBlobStore.encodeTargetBlobNameTagValue(blobName);
+
+        assertThat(encoded).isNotEqualTo(blobName);
+        assertThat(AzureBlobStore.decodeTargetBlobNameTagValue(encoded))
+                .isEqualTo(blobName);
+
+        String legacyPlain = "legacy/blob/name";
+        assertThat(AzureBlobStore.decodeTargetBlobNameTagValue(legacyPlain))
+                .isEqualTo(legacyPlain);
+
+        String legacyPrefix = "base64url:legacy-not-base64-*";
+        assertThat(AzureBlobStore.decodeTargetBlobNameTagValue(legacyPrefix))
+                .isEqualTo(legacyPrefix);
+
+        String legacyBase64 = "base64url:" + Base64.getUrlEncoder()
+                .withoutPadding()
+                .encodeToString("legacy-markerless".getBytes(StandardCharsets.UTF_8));
+        assertThat(AzureBlobStore.decodeTargetBlobNameTagValue(legacyBase64))
+                .isEqualTo(legacyBase64);
+    }
+}


### PR DESCRIPTION
Blob names have a wider set of permitted characters than tag values, so it's possible for the target blob name tag to cause an error even though the blob itself will create successfully.

This will now base64-encode the blob name to ensure it's always writable.

This would be a smaller patch, but I wanted to ensure there are two backwards-compatible safeties:
1. Values without the base64 marker will continue to decode correctly
2. Values with the base64 marker but without an internal marker will decode as-is, which handles the case where an s3proxy client happens to use the same base64 marker string for some reason

Tested via `mvn test`, and by running a custom build in production to confirm the fix works.