### PR TITLE
Harden SFTP bridge backup validation and real backup-settings smoke path

### DIFF
--- a/docs/backends/sftp.md
+++ b/docs/backends/sftp.md
@@ -1,0 +1,105 @@
+# SFTP Backend
+
+Status: S3 backup profile validated
+
+The SFTP backend will expose an SFTP server as an S3Proxy storage backend behind
+the jclouds `BlobStore` interface. The S3 protocol layer should remain
+provider-neutral.
+
+The initial validation target is the S3 backup to SFTP bridge described in
+`docs/compatibility/s3-backup-sftp-bridge.md`.
+
+## Implementation Status
+
+The first provider spike exists under `org.gaul.s3proxy.sftp`:
+
+- `SftpBlobStoreProviderMetadata`
+- `SftpBlobStoreApiMetadata`
+- `SftpBlobStoreContextModule`
+- `SftpBlobStore`
+
+The provider reuses the existing NIO.2 blobstore implementation over Apache MINA
+SSHD's SFTP filesystem provider. This keeps the first implementation small and
+preserves the existing BlobStore behavior surface where the remote filesystem
+supports it.
+
+## Planned Configuration
+
+Example shape:
+
+```
+s3proxy.authorization=aws-v2-or-v4
+s3proxy.endpoint=http://127.0.0.1:8080
+s3proxy.identity=local-identity
+s3proxy.credential=local-credential
+
+jclouds.provider=sftp
+jclouds.endpoint=sftp://127.0.0.1:2222/
+jclouds.identity=sftp-user
+jclouds.credential=sftp-password
+jclouds.sftp.basedir=/upload-root
+```
+
+The final implementation may add key-file authentication, host-key pinning, and
+connection timeout properties. These must be reflected here and in
+`src/test/resources/s3proxy-sftp.conf`.
+
+## Storage Mapping
+
+- S3 buckets map to first-level directories below `jclouds.sftp.basedir`.
+- Object keys map to files below the bucket directory.
+- Keys ending in `/` are directory marker requests.
+- All path resolution must normalize and reject traversal outside the configured
+  base directory.
+
+Effective path mapping is:
+
+`<jclouds.sftp.basedir>/<bucket>/<object-key>`
+
+Example:
+
+- `jclouds.sftp.basedir=/data/backups`
+- S3 bucket name: `example-bucket`
+- Object key: `backups/app/1000/db_dump.zip`
+
+Stored file path:
+
+`/data/backups/example-bucket/backups/app/1000/db_dump.zip`
+
+## Metadata Contract
+
+The existing NIO.2 backend stores content metadata and user metadata in user
+extended attributes. SFTP servers generally do not provide portable user xattrs.
+
+The first milestone uses reduced metadata fidelity:
+
+- Object bytes are stored as regular SFTP files.
+- Object size and last-modified come from SFTP file attributes.
+- Content type is inferred when persisted content-type metadata is unavailable.
+- ETags are generated during upload, but portable persistence across reconnects
+  is not guaranteed without sidecar metadata.
+- S3 user metadata is not portable over SFTP and is not part of the S3 backup
+  acceptance profile.
+
+The shared NIO.2 backend now treats unsupported user xattrs as optional. That is
+required for Apache MINA's SFTP filesystem and is also safer for other
+filesystems that do not expose `UserDefinedFileAttributeView`.
+
+## Validation Lanes
+
+- Fixture lane: provider construction, config parsing, and path-safety tests.
+- Embedded lane: run tests against an embedded Apache MINA SSHD SFTP server.
+- S3 backup lane: prove the specific S3 operations used by an S3 backup client
+  before broad S3 compatibility.
+- S3 lane: run `AwsSdkTest` and `run-s3-tests.sh` with
+  `s3proxy-sftp.conf`.
+- External lane: optional validation against a real SFTP host with credentials
+  supplied outside git.
+
+## Non-Goals
+
+- SFTP-specific S3 protocol extensions.
+- Shell access or remote command execution.
+- Cross-user remote filesystem administration.
+- Claiming full S3 metadata parity until the selected metadata strategy proves
+  it with tests.

--- a/docs/compatibility/s3-backup-sftp-bridge.md
+++ b/docs/compatibility/s3-backup-sftp-bridge.md
@@ -1,0 +1,105 @@
+# S3 Backup to SFTP Bridge
+
+Status: embedded SFTP profile validated
+
+## Problem
+
+An application backup/restore workflow currently writes backups through an
+S3-compatible storage interface. The backup target is reachable over SFTP. The
+bridge lets an S3 backup client keep using its S3 settings while S3Proxy
+translates those S3 operations to the SFTP server.
+
+Target deployment shape:
+
+```
+S3 backup client -> S3Proxy endpoint -> SFTP backend -> SFTP root
+```
+
+## S3 Client Configuration Shape
+
+An S3 backup client configuration commonly supports:
+
+- `accessKey`
+- `secretKey`
+- `bucketName`
+- `serviceEndpoint`
+- `disableSslValidation`
+- `certificate`
+- `writeOnly`
+- `disableChecksumValidation`
+
+For this bridge, `serviceEndpoint` should point at S3Proxy and `bucketName`
+should be the S3Proxy bucket that maps to the SFTP remote directory.
+S3Proxy authentication credentials should remain distinct from backend SFTP
+credentials.
+
+Path formula:
+
+`remote_path = jclouds.sftp.basedir / bucketName / objectKey`
+
+So `bucketName` is not ignored: it is the first folder level under the SFTP
+base directory for all backup objects.
+
+## Required S3 Operations
+
+The S3 backup path uses the following S3 operations through AWS SDK v2:
+
+- `putObject` for backup payload objects and `entry.txt` metadata objects;
+- `headObject` before reading a payload object;
+- `getObject` for backup payload objects and `entry.txt` metadata objects;
+- `listObjectsV2` with a prefix such as `backups/snapshot/`;
+- `deleteObject` for payload objects and metadata objects.
+
+The AWS SDK v2 client uses path-style access and a configurable endpoint
+override. Region parsing falls back to `us-east-1` for S3-compatible endpoints.
+
+## Key Layout
+
+An S3 backup workflow stores entries under a configured prefix, commonly:
+
+```
+backups/snapshot/<snapshot-id>/snapshot.zip
+backups/snapshot/<snapshot-id>/entry.txt
+backups/app/<backup-id>/db_dump.zip
+backups/app/<backup-id>/entry.txt
+```
+
+The SFTP backend must preserve this hierarchy under the configured remote base
+directory.
+
+## First Acceptance Test
+
+`S3BackupSftpBridgeTest` starts S3Proxy with the SFTP backend pointed at an
+embedded SFTP server, then runs the equivalent of:
+
+1. Create bucket.
+2. Upload `backups/snapshot/100/snapshot.zip`.
+3. Upload `backups/snapshot/100/entry.txt`.
+4. Upload `backups/app/1000/db_dump.zip`.
+5. Upload `backups/app/1000/entry.txt`.
+6. `HEAD` the payload objects.
+7. `GET` the payload and metadata objects.
+8. List `backups/snapshot/` and `backups/app/`.
+9. Delete the payload and metadata objects.
+
+The test includes multi-megabyte payload objects through AWS SDK v2's async S3
+client with path-style access and a custom endpoint. The SDK completed the
+current payloads as single-part uploads; multipart remains a later compatibility
+lane for larger payload thresholds.
+
+## Operational Notes
+
+- S3Proxy should be deployed near the S3 backup client or near the SFTP server,
+  depending on network policy and latency.
+- TLS for S3-client-to-S3Proxy should be enabled for SFTP target deployment unless
+  traffic is constrained to a trusted local network.
+- SFTP host key verification and credential handling must be explicit before
+  production use.
+- If the SFTP server grants write-only SFTP semantics, restore and list behavior
+  will not work. Restore requires reads and listing.
+
+## Success Boundary
+
+This profile is green when the S3 backup operation set works end-to-end through
+S3Proxy to embedded SFTP and then to an external SFTP server. Full S3 API
+compatibility is useful later, but it is not the first success boundary.

--- a/pom.xml
+++ b/pom.xml
@@ -585,6 +585,11 @@
       <version>${jclouds.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.sshd</groupId>
+      <artifactId>sshd-sftp</artifactId>
+      <version>2.17.1</version>
+    </dependency>
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/src/main/java/org/gaul/s3proxy/nio2blob/AbstractNio2BlobStore.java
+++ b/src/main/java/org/gaul/s3proxy/nio2blob/AbstractNio2BlobStore.java
@@ -585,7 +585,7 @@ public abstract class AbstractNio2BlobStore extends BaseBlobStore {
                 throw new RuntimeException(ioe);
             }
 
-            var view = Files.getFileAttributeView(path, UserDefinedFileAttributeView.class);
+            var view = getXattrView(path);
             if (view != null) {
                 try {
                     writeCommonMetadataAttr(view, blob);
@@ -618,7 +618,7 @@ public abstract class AbstractNio2BlobStore extends BaseBlobStore {
                 throw returnResponseException(400);
             }
 
-            var view = Files.getFileAttributeView(tmpPath, UserDefinedFileAttributeView.class);
+            var view = getXattrView(tmpPath);
             if (view != null) {
                 try {
                     var eTag = actualHashCode.asBytes();
@@ -1186,7 +1186,7 @@ public abstract class AbstractNio2BlobStore extends BaseBlobStore {
      * (e.g., Docker Desktop bind mounts via VirtioFS, some NFS/NAS mounts).
      */
     private static XattrState safeGetXattrs(Path path) {
-        var view = Files.getFileAttributeView(path, UserDefinedFileAttributeView.class);
+        var view = getXattrView(path);
         if (view == null) {
             return XattrState.EMPTY;
         }
@@ -1195,6 +1195,16 @@ public abstract class AbstractNio2BlobStore extends BaseBlobStore {
         } catch (IOException e) {
             logger.debug("xattrs not supported on {}", path);
             return XattrState.EMPTY;
+        }
+    }
+
+    private static UserDefinedFileAttributeView getXattrView(Path path) {
+        try {
+            return Files.getFileAttributeView(path,
+                    UserDefinedFileAttributeView.class);
+        } catch (UnsupportedOperationException uoe) {
+            logger.debug("xattrs not supported on {}", path);
+            return null;
         }
     }
 

--- a/src/main/java/org/gaul/s3proxy/sftp/SftpBlobStore.java
+++ b/src/main/java/org/gaul/s3proxy/sftp/SftpBlobStore.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2014-2026 Andrew Gaul <andrew@gaul.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gaul.s3proxy.sftp;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.base.Supplier;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+import org.apache.sshd.sftp.client.fs.SftpFileSystemProvider;
+import org.gaul.s3proxy.nio2blob.AbstractNio2BlobStore;
+import org.jclouds.blobstore.BlobStoreContext;
+import org.jclouds.blobstore.util.BlobUtils;
+import org.jclouds.collect.Memoized;
+import org.jclouds.domain.Credentials;
+import org.jclouds.domain.Location;
+import org.jclouds.io.PayloadSlicer;
+import org.jclouds.providers.ProviderMetadata;
+
+@Singleton
+public final class SftpBlobStore extends AbstractNio2BlobStore {
+    @Inject
+    SftpBlobStore(BlobStoreContext context, BlobUtils blobUtils,
+            Supplier<Location> defaultLocation,
+            @Memoized Supplier<Set<? extends Location>> locations,
+            PayloadSlicer slicer,
+            @org.jclouds.location.Provider Supplier<Credentials> creds,
+            ProviderMetadata provider,
+            @Named(SftpBlobStoreApiMetadata.BASEDIR) String baseDir) {
+        super(context, blobUtils, defaultLocation, locations, slicer, creds,
+                createRoot(provider, creds.get(), baseDir));
+    }
+
+    private static Path createRoot(ProviderMetadata provider, Credentials creds,
+            String baseDir) {
+        var endpoint = URI.create(provider.getEndpoint());
+        int port = endpoint.getPort();
+        var uri = SftpFileSystemProvider.createFileSystemURI(
+                endpoint.getHost(), port, creds.identity, creds.credential);
+        try {
+            var fs = new SftpFileSystemProvider().newFileSystem(uri, Map.of());
+            var root = fs.getPath(baseDir).normalize();
+            Files.createDirectories(root);
+            return root;
+        } catch (IOException ioe) {
+            throw new RuntimeException("Failed to initialize SFTP backend", ioe);
+        }
+    }
+}

--- a/src/main/java/org/gaul/s3proxy/sftp/SftpBlobStoreApiMetadata.java
+++ b/src/main/java/org/gaul/s3proxy/sftp/SftpBlobStoreApiMetadata.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2014-2026 Andrew Gaul <andrew@gaul.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gaul.s3proxy.sftp;
+
+import java.net.URI;
+import java.util.Properties;
+import java.util.Set;
+
+import org.jclouds.blobstore.BlobStoreContext;
+import org.jclouds.reflect.Reflection2;
+import org.jclouds.rest.internal.BaseHttpApiMetadata;
+
+@SuppressWarnings("rawtypes")
+public final class SftpBlobStoreApiMetadata extends BaseHttpApiMetadata {
+    public static final String BASEDIR = "jclouds.sftp.basedir";
+
+    public SftpBlobStoreApiMetadata() {
+        this(builder());
+    }
+
+    protected SftpBlobStoreApiMetadata(Builder builder) {
+        super(builder);
+    }
+
+    private static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return builder().fromApiMetadata(this);
+    }
+
+    public static Properties defaultProperties() {
+        Properties properties = BaseHttpApiMetadata.defaultProperties();
+        properties.setProperty(BASEDIR, "/");
+        return properties;
+    }
+
+    // Fake API client
+    private interface SftpBlobStoreClient {
+    }
+
+    public static final class Builder
+            extends BaseHttpApiMetadata.Builder<SftpBlobStoreClient, Builder> {
+        protected Builder() {
+            super(SftpBlobStoreClient.class);
+            id("sftp")
+                .name("SFTP Blobstore")
+                .identityName("Username")
+                .credentialName("Password")
+                .defaultEndpoint("sftp://127.0.0.1:22/")
+                .documentation(URI.create(
+                        "http://www.jclouds.org/documentation/userguide" +
+                        "/blobstore-guide"))
+                .defaultProperties(SftpBlobStoreApiMetadata.defaultProperties())
+                .view(Reflection2.typeToken(BlobStoreContext.class))
+                .defaultModules(Set.of(SftpBlobStoreContextModule.class));
+        }
+
+        @Override
+        public SftpBlobStoreApiMetadata build() {
+            return new SftpBlobStoreApiMetadata(this);
+        }
+
+        @Override
+        protected Builder self() {
+            return this;
+        }
+    }
+}

--- a/src/main/java/org/gaul/s3proxy/sftp/SftpBlobStoreContextModule.java
+++ b/src/main/java/org/gaul/s3proxy/sftp/SftpBlobStoreContextModule.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2014-2026 Andrew Gaul <andrew@gaul.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gaul.s3proxy.sftp;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Scopes;
+
+import org.jclouds.blobstore.BlobStore;
+import org.jclouds.blobstore.attr.ConsistencyModel;
+
+public final class SftpBlobStoreContextModule extends AbstractModule {
+    @Override
+    protected void configure() {
+        bind(ConsistencyModel.class).toInstance(ConsistencyModel.STRICT);
+        bind(BlobStore.class).to(SftpBlobStore.class).in(Scopes.SINGLETON);
+    }
+}

--- a/src/main/java/org/gaul/s3proxy/sftp/SftpBlobStoreProviderMetadata.java
+++ b/src/main/java/org/gaul/s3proxy/sftp/SftpBlobStoreProviderMetadata.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2014-2026 Andrew Gaul <andrew@gaul.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gaul.s3proxy.sftp;
+
+import java.util.Properties;
+
+import com.google.auto.service.AutoService;
+
+import org.jclouds.providers.ProviderMetadata;
+import org.jclouds.providers.internal.BaseProviderMetadata;
+
+@AutoService(ProviderMetadata.class)
+public final class SftpBlobStoreProviderMetadata extends BaseProviderMetadata {
+    public SftpBlobStoreProviderMetadata() {
+        super(builder());
+    }
+
+    public SftpBlobStoreProviderMetadata(Builder builder) {
+        super(builder);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return builder().fromProviderMetadata(this);
+    }
+
+    public static Properties defaultProperties() {
+        return new Properties();
+    }
+
+    public static final class Builder extends BaseProviderMetadata.Builder {
+        protected Builder() {
+            id("sftp")
+                .name("SFTP blobstore")
+                .apiMetadata(new SftpBlobStoreApiMetadata())
+                .endpoint("sftp://127.0.0.1:22/")
+                .defaultProperties(
+                        SftpBlobStoreProviderMetadata.defaultProperties());
+        }
+
+        @Override
+        public SftpBlobStoreProviderMetadata build() {
+            return new SftpBlobStoreProviderMetadata(this);
+        }
+
+        @Override
+        public Builder fromProviderMetadata(ProviderMetadata in) {
+            super.fromProviderMetadata(in);
+            return this;
+        }
+    }
+}

--- a/src/test/java/org/gaul/s3proxy/LocalS3BackupClientSmokeTest.java
+++ b/src/test/java/org/gaul/s3proxy/LocalS3BackupClientSmokeTest.java
@@ -1,0 +1,379 @@
+/*
+ * Copyright 2014-2026 Andrew Gaul <andrew@gaul.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gaul.s3proxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assume.assumeTrue;
+
+import java.io.IOException;
+import java.net.CookieManager;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+import org.apache.sshd.common.file.virtualfs.VirtualFileSystemFactory;
+import org.apache.sshd.server.SshServer;
+import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
+import org.apache.sshd.sftp.server.SftpSubsystemFactory;
+import org.gaul.s3proxy.sftp.SftpBlobStoreApiMetadata;
+import org.jclouds.Constants;
+import org.jclouds.ContextBuilder;
+import org.jclouds.blobstore.BlobStoreContext;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.checksums.RequestChecksumCalculation;
+import software.amazon.awssdk.core.checksums.ResponseChecksumValidation;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3Configuration;
+
+public final class LocalS3BackupClientSmokeTest {
+    private static final String SFTP_USER = "sftp-user";
+    private static final String SFTP_PASSWORD = "sftp-password";
+    private static final String S3_IDENTITY = "local-identity";
+    private static final String S3_CREDENTIAL = "local-credential";
+    private static final String BUCKET = "s3-backup-smoke";
+    private static final String DEFAULT_APP_BASE_URL = "https://localhost:8443";
+    private static final String DEFAULT_CSRF_PATH = "/api/public/csrf";
+    private static final String DEFAULT_S3PROXY_BIND_HOST = "127.0.0.1";
+    private static final String DEFAULT_S3PROXY_ADVERTISED_HOST =
+            "127.0.0.1";
+    private static final Pattern CSRF_TOKEN = Pattern.compile(
+            "\"token\"\\s*:\\s*\"([^\"]+)\"");
+    private static final Pattern CSRF_PARAMETER = Pattern.compile(
+            "\"parameterName\"\\s*:\\s*\"([^\"]+)\"");
+    private static final Pattern CSRF_HEADER = Pattern.compile(
+            "\"headerName\"\\s*:\\s*\"([^\"]+)\"");
+
+    private SshServer sshServer;
+    private BlobStoreContext context;
+    private S3Proxy s3Proxy;
+    private S3AsyncClient s3Client;
+    private URI s3Endpoint;
+    private String s3Identity;
+    private String s3Credential;
+    private String bucketName;
+
+    @Before
+    public void setUp() throws Exception {
+        assumeTrue("set S3PROXY_SMOKE_APP_USERNAME and " +
+                "S3PROXY_SMOKE_APP_PASSWORD to run the local smoke test",
+                requiredSetting("app.username").isPresent() &&
+                requiredSetting("app.password").isPresent());
+
+        s3Identity = setting("s3.identity", S3_IDENTITY);
+        s3Credential = setting("s3.credential", S3_CREDENTIAL);
+        bucketName = setting("s3.bucket", BUCKET);
+        var externalEndpoint = requiredSetting("s3.externalEndpoint");
+        if (externalEndpoint.isPresent()) {
+            s3Endpoint = URI.create(externalEndpoint.orElseThrow());
+            if (booleanSetting("s3.manageBucket", false)) {
+                s3Client = buildS3Client(s3Endpoint, s3Identity, s3Credential);
+                get(s3Client.createBucket(request -> request.bucket(bucketName)));
+            }
+            return;
+        }
+
+        var s3ProxyBindHost = setting("s3proxy.bindHost",
+                DEFAULT_S3PROXY_BIND_HOST);
+        var s3ProxyBindPort = intSetting("s3proxy.bindPort", 0);
+        var s3ProxyAdvertisedHost = setting("s3proxy.advertisedHost",
+                DEFAULT_S3PROXY_ADVERTISED_HOST);
+        var s3ProxyAdvertisedPort = intSetting("s3proxy.advertisedPort",
+                s3ProxyBindPort);
+
+        var sftpRoot = Files.createTempDirectory("s3proxy-sftp-smoke-root");
+        sshServer = SshServer.setUpDefaultServer();
+        sshServer.setHost("127.0.0.1");
+        sshServer.setPort(0);
+        sshServer.setKeyPairProvider(new SimpleGeneratorHostKeyProvider(
+                Files.createTempFile("s3proxy-sftp-smoke-hostkey", ".ser")));
+        sshServer.setPasswordAuthenticator((username, password, session) ->
+                SFTP_USER.equals(username) && SFTP_PASSWORD.equals(password));
+        sshServer.setFileSystemFactory(new VirtualFileSystemFactory(sftpRoot));
+        sshServer.setSubsystemFactories(List.of(
+                new SftpSubsystemFactory.Builder().build()));
+        sshServer.start();
+
+        var properties = new Properties();
+        properties.setProperty(Constants.PROPERTY_ENDPOINT,
+                "sftp://127.0.0.1:" + sshServer.getPort() + "/");
+        properties.setProperty(SftpBlobStoreApiMetadata.BASEDIR, "/");
+        context = ContextBuilder.newBuilder("sftp")
+                .credentials(SFTP_USER, SFTP_PASSWORD)
+                .overrides(properties)
+                .build(BlobStoreContext.class);
+
+        s3Proxy = S3Proxy.builder()
+                .endpoint(URI.create("http://" + s3ProxyBindHost + ":" +
+                        s3ProxyBindPort))
+                .awsAuthentication(AuthenticationType.AWS_V2_OR_V4,
+                        S3_IDENTITY, S3_CREDENTIAL)
+                .blobStore(context.getBlobStore())
+                .ignoreUnknownHeaders(true)
+                .build();
+        s3Proxy.start();
+        if (s3ProxyAdvertisedPort == 0) {
+            s3ProxyAdvertisedPort = s3Proxy.getPort();
+        }
+        s3Endpoint = URI.create("http://" + s3ProxyAdvertisedHost + ":" +
+                s3ProxyAdvertisedPort);
+
+        s3Client = buildS3Client(s3Endpoint, s3Identity, s3Credential);
+        get(s3Client.createBucket(request -> request.bucket(bucketName)));
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (s3Client != null) {
+            try {
+                get(s3Client.deleteBucket(request -> request.bucket(bucketName)));
+            } catch (Exception ignored) {
+                // Best effort cleanup after a failed smoke.
+            }
+            s3Client.close();
+        }
+        if (s3Proxy != null) {
+            s3Proxy.stop();
+        }
+        if (context != null) {
+            context.close();
+        }
+        if (sshServer != null) {
+            sshServer.stop();
+        }
+    }
+
+    @Test
+    public void testLocalApplicationS3BackupConnectivity() throws Exception {
+        var client = appHttpClient();
+        var baseUrl = setting("app.baseUrl", DEFAULT_APP_BASE_URL);
+        var csrfPath = setting("app.csrfPath", DEFAULT_CSRF_PATH);
+        var loginPath = setting("app.loginPath", "/login");
+        var testPath = setting("app.s3TestPath",
+                "/api/backup-settings?storageType=S3&action=test");
+        var savePath = setting("app.s3SavePath",
+                "/api/backup-settings/storage?storageType=S3");
+        var saveMethod = setting("app.s3SaveMethod", "PATCH");
+        var persistSettings = booleanSetting("app.persistSettings", false);
+
+        var loginCsrf = fetchCsrf(client, baseUrl, csrfPath);
+        login(client, baseUrl, loginPath, loginCsrf);
+        var csrf = fetchCsrf(client, baseUrl, csrfPath);
+
+        var body = """
+                {
+                  "accessKey": "%s",
+                  "secretKey": "%s",
+                  "bucketName": "%s",
+                  "serviceEndpoint": "%s",
+                  "disableChecksumValidation": true
+                }
+                """.formatted(s3Identity, s3Credential, bucketName, s3Endpoint);
+
+        var response = client.send(HttpRequest.newBuilder(resolve(baseUrl,
+                        testPath))
+                .header("Content-Type", "application/json")
+                .header(csrf.headerName(), csrf.token())
+                .POST(HttpRequest.BodyPublishers.ofString(body))
+                .build(), HttpResponse.BodyHandlers.ofString());
+
+        assertThat(response.statusCode()).as(response.body()).isBetween(200, 299);
+        assertThat(response.body()).doesNotContain("\"error\"");
+
+        if (!persistSettings) {
+            return;
+        }
+
+        var saveBody = """
+                {
+                  "serviceEndpoint": "%s",
+                  "disableSslValidation": false,
+                  "disableChecksumValidation": false,
+                  "certificate": null,
+                  "bucketName": "%s",
+                  "accessKey": "%s",
+                  "secretKey": "%s",
+                  "writeOnly": false
+                }
+                """.formatted(s3Endpoint, bucketName, s3Identity, s3Credential);
+        var saveRequest = HttpRequest.newBuilder(resolve(baseUrl, savePath))
+                .header("Content-Type", "application/json")
+                .header(csrf.headerName(), csrf.token())
+                .method(saveMethod, HttpRequest.BodyPublishers.ofString(saveBody))
+                .build();
+        var saveResponse = client.send(saveRequest,
+                HttpResponse.BodyHandlers.ofString());
+        assertThat(saveResponse.statusCode()).as(saveResponse.body())
+                .isBetween(200, 299);
+    }
+
+    private static SmokeCsrf fetchCsrf(HttpClient client, String baseUrl,
+            String csrfPath) throws IOException, InterruptedException {
+        var response = client.send(HttpRequest.newBuilder(resolve(baseUrl,
+                        csrfPath))
+                .GET()
+                .build(), HttpResponse.BodyHandlers.ofString());
+        assertThat(response.statusCode()).isBetween(200, 299);
+        return new SmokeCsrf(
+                match(response.body(), CSRF_PARAMETER),
+                match(response.body(), CSRF_TOKEN),
+                match(response.body(), CSRF_HEADER));
+    }
+
+    private static void login(HttpClient client, String baseUrl,
+            String loginPath, SmokeCsrf csrf)
+            throws IOException, InterruptedException {
+        var username = requiredSetting("app.username").orElseThrow();
+        var password = requiredSetting("app.password").orElseThrow();
+        var form = csrf.parameterName() + "=" + encode(csrf.token()) +
+                "&username=" + encode(username) +
+                "&password=" + encode(password);
+        var response = client.send(HttpRequest.newBuilder(resolve(baseUrl,
+                        loginPath))
+                .header(csrf.headerName(), csrf.token())
+                .header("Content-Type",
+                        "application/x-www-form-urlencoded")
+                .POST(HttpRequest.BodyPublishers.ofString(form))
+                .build(), HttpResponse.BodyHandlers.ofString());
+        assertThat(response.statusCode()).isBetween(200, 399);
+    }
+
+    private static HttpClient appHttpClient()
+            throws NoSuchAlgorithmException, KeyManagementException {
+        var cookieManager = new CookieManager();
+        return HttpClient.newBuilder()
+                .cookieHandler(cookieManager)
+                .followRedirects(HttpClient.Redirect.NORMAL)
+                .sslContext(trustAllSslContext())
+                .build();
+    }
+
+    private static SSLContext trustAllSslContext()
+            throws NoSuchAlgorithmException, KeyManagementException {
+        var trustManager = new X509TrustManager() {
+            @Override
+            public void checkClientTrusted(X509Certificate[] chain,
+                    String authType) {
+            }
+
+            @Override
+            public void checkServerTrusted(X509Certificate[] chain,
+                    String authType) {
+            }
+
+            @Override
+            public X509Certificate[] getAcceptedIssuers() {
+                return new X509Certificate[0];
+            }
+        };
+        var context = SSLContext.getInstance("TLS");
+        context.init(null, new TrustManager[] {trustManager},
+                new SecureRandom());
+        return context;
+    }
+
+    private static URI resolve(String baseUrl, String path) {
+        return URI.create(baseUrl).resolve(path);
+    }
+
+    private static String match(String body, Pattern pattern) {
+        var matcher = pattern.matcher(body);
+        assertThat(matcher.find()).isTrue();
+        return matcher.group(1);
+    }
+
+    private static String encode(String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
+    }
+
+    private static String setting(String key, String defaultValue) {
+        return requiredSetting(key).orElse(defaultValue);
+    }
+
+    private static int intSetting(String key, int defaultValue) {
+        return requiredSetting(key).map(Integer::parseInt)
+                .orElse(defaultValue);
+    }
+
+    private static boolean booleanSetting(String key, boolean defaultValue) {
+        return requiredSetting(key).map(Boolean::parseBoolean)
+                .orElse(defaultValue);
+    }
+
+    private static java.util.Optional<String> requiredSetting(String key) {
+        var systemProperty = System.getProperty("s3proxy.smoke." + key);
+        if (systemProperty != null && !systemProperty.isBlank()) {
+            return java.util.Optional.of(systemProperty);
+        }
+        var envName = "S3PROXY_SMOKE_" + key.replace('.', '_')
+                .toUpperCase(java.util.Locale.ROOT);
+        var envValue = System.getenv(envName);
+        if (envValue != null && !envValue.isBlank()) {
+            return java.util.Optional.of(envValue);
+        }
+        return java.util.Optional.empty();
+    }
+
+    private static <T> T get(CompletableFuture<T> future) throws Exception {
+        return future.get(30, TimeUnit.SECONDS);
+    }
+
+    private static S3AsyncClient buildS3Client(URI endpoint, String identity,
+            String credential) {
+        return S3AsyncClient.builder()
+                .multipartEnabled(true)
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(identity, credential)))
+                .region(Region.US_EAST_1)
+                .endpointOverride(endpoint)
+                .requestChecksumCalculation(
+                        RequestChecksumCalculation.WHEN_REQUIRED)
+                .responseChecksumValidation(
+                        ResponseChecksumValidation.WHEN_REQUIRED)
+                .serviceConfiguration(S3Configuration.builder()
+                        .pathStyleAccessEnabled(true)
+                        .chunkedEncodingEnabled(false)
+                        .build())
+                .build();
+    }
+
+    private record SmokeCsrf(String parameterName, String token,
+            String headerName) {
+    }
+}

--- a/src/test/java/org/gaul/s3proxy/S3BackupSftpBridgeTest.java
+++ b/src/test/java/org/gaul/s3proxy/S3BackupSftpBridgeTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2014-2026 Andrew Gaul <andrew@gaul.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gaul.s3proxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.sshd.common.file.virtualfs.VirtualFileSystemFactory;
+import org.apache.sshd.server.SshServer;
+import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
+import org.apache.sshd.sftp.server.SftpSubsystemFactory;
+import org.gaul.s3proxy.sftp.SftpBlobStoreApiMetadata;
+import org.jclouds.Constants;
+import org.jclouds.ContextBuilder;
+import org.jclouds.blobstore.BlobStoreContext;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.core.checksums.RequestChecksumCalculation;
+import software.amazon.awssdk.core.checksums.ResponseChecksumValidation;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3Configuration;
+
+public final class S3BackupSftpBridgeTest {
+    private static final String SFTP_USER = "sftp-user";
+    private static final String SFTP_PASSWORD = "sftp-password";
+    private static final String S3_IDENTITY = "local-identity";
+    private static final String S3_CREDENTIAL = "local-credential";
+
+    private SshServer sshServer;
+    private BlobStoreContext context;
+    private S3Proxy s3Proxy;
+    private S3AsyncClient s3Client;
+    private Path sftpRoot;
+
+    @Before
+    public void setUp() throws Exception {
+        sftpRoot = Files.createTempDirectory("s3proxy-sftp-root");
+        sshServer = SshServer.setUpDefaultServer();
+        sshServer.setHost("127.0.0.1");
+        sshServer.setPort(0);
+        sshServer.setKeyPairProvider(new SimpleGeneratorHostKeyProvider(
+                Files.createTempFile("s3proxy-sftp-hostkey", ".ser")));
+        sshServer.setPasswordAuthenticator((username, password, session) ->
+                SFTP_USER.equals(username) && SFTP_PASSWORD.equals(password));
+        sshServer.setFileSystemFactory(new VirtualFileSystemFactory(sftpRoot));
+        sshServer.setSubsystemFactories(List.of(
+                new SftpSubsystemFactory.Builder().build()));
+        sshServer.start();
+
+        var properties = new Properties();
+        properties.setProperty(Constants.PROPERTY_ENDPOINT,
+                "sftp://127.0.0.1:" + sshServer.getPort() + "/");
+        properties.setProperty(SftpBlobStoreApiMetadata.BASEDIR, "/");
+        context = ContextBuilder.newBuilder("sftp")
+                .credentials(SFTP_USER, SFTP_PASSWORD)
+                .overrides(properties)
+                .build(BlobStoreContext.class);
+
+        s3Proxy = S3Proxy.builder()
+                .endpoint(URI.create("http://127.0.0.1:0"))
+                .awsAuthentication(AuthenticationType.AWS_V2_OR_V4,
+                        S3_IDENTITY, S3_CREDENTIAL)
+                .blobStore(context.getBlobStore())
+                .ignoreUnknownHeaders(true)
+                .build();
+        s3Proxy.start();
+
+        s3Client = S3AsyncClient.builder()
+                .multipartEnabled(true)
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(S3_IDENTITY, S3_CREDENTIAL)))
+                .region(Region.US_EAST_1)
+                .endpointOverride(
+                        URI.create("http://127.0.0.1:" + s3Proxy.getPort()))
+                .requestChecksumCalculation(
+                        RequestChecksumCalculation.WHEN_REQUIRED)
+                .responseChecksumValidation(
+                        ResponseChecksumValidation.WHEN_REQUIRED)
+                .serviceConfiguration(S3Configuration.builder()
+                        .pathStyleAccessEnabled(true)
+                        .chunkedEncodingEnabled(false)
+                        .build())
+                .build();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (s3Client != null) {
+            s3Client.close();
+        }
+        if (s3Proxy != null) {
+            s3Proxy.stop();
+        }
+        if (context != null) {
+            context.close();
+        }
+        if (sshServer != null) {
+            sshServer.stop();
+        }
+    }
+
+    @Test
+    public void testS3BackupOperationProfile() throws Exception {
+        var bucket = "s3-backup";
+        var snapshotPayload = "backups/snapshot/100/snapshot.zip";
+        var snapshotEntry = "backups/snapshot/100/entry.txt";
+        var appPayload = "backups/app/1000/db_dump.zip";
+        var appEntry = "backups/app/1000/entry.txt";
+
+        get(s3Client.createBucket(request -> request.bucket(bucket)));
+        putObject(bucket, snapshotPayload, bytes(1024 * 1024));
+        putObject(bucket, snapshotEntry, "snapshot-entry".getBytes(
+                StandardCharsets.UTF_8));
+        putObject(bucket, appPayload, bytes(2 * 1024 * 1024));
+        putObject(bucket, appEntry, "app-entry".getBytes(StandardCharsets.UTF_8));
+
+        assertThat(get(s3Client.headObject(request -> request.bucket(bucket)
+                .key(snapshotPayload))).contentLength()).isEqualTo(1024 * 1024);
+        assertThat(get(s3Client.getObject(request -> request.bucket(bucket)
+                .key(snapshotEntry), AsyncResponseTransformer.toBytes()))
+                .asUtf8String()).isEqualTo("snapshot-entry");
+        assertThat(get(s3Client.getObject(request -> request.bucket(bucket)
+                .key(appEntry), AsyncResponseTransformer.toBytes()))
+                .asUtf8String()).isEqualTo("app-entry");
+        assertThat(Files.exists(sftpRoot.resolve(bucket).resolve(snapshotPayload)))
+                .isTrue();
+        assertThat(Files.exists(sftpRoot.resolve(bucket).resolve(snapshotEntry)))
+                .isTrue();
+        assertThat(Files.exists(sftpRoot.resolve(bucket).resolve(appPayload)))
+                .isTrue();
+        assertThat(Files.exists(sftpRoot.resolve(bucket).resolve(appEntry)))
+                .isTrue();
+
+        var snapshotKeys = get(s3Client.listObjectsV2(request -> request
+                .bucket(bucket)
+                .prefix("backups/snapshot/"))).contents();
+        assertThat(snapshotKeys).extracting(object -> object.key())
+                .containsExactlyInAnyOrder(snapshotPayload, snapshotEntry);
+
+        get(s3Client.deleteObject(request -> request.bucket(bucket)
+                .key(snapshotEntry)));
+        get(s3Client.deleteObject(request -> request.bucket(bucket)
+                .key(snapshotPayload)));
+        get(s3Client.deleteObject(request -> request.bucket(bucket)
+                .key(appEntry)));
+        get(s3Client.deleteObject(request -> request.bucket(bucket)
+                .key(appPayload)));
+        get(s3Client.deleteBucket(request -> request.bucket(bucket)));
+    }
+
+    private void putObject(String bucket, String key, byte[] content)
+            throws Exception {
+        get(s3Client.putObject(request -> request.bucket(bucket).key(key),
+                AsyncRequestBody.fromBytes(content)));
+    }
+
+    private static <T> T get(CompletableFuture<T> future) throws Exception {
+        return future.get(30, TimeUnit.SECONDS);
+    }
+
+    private static byte[] bytes(int size) {
+        var bytes = new byte[size];
+        for (int i = 0; i < size; i++) {
+            bytes[i] = (byte) (i & 0xff);
+        }
+        return bytes;
+    }
+}

--- a/src/test/java/org/gaul/s3proxy/sftp/SftpBlobStoreTest.java
+++ b/src/test/java/org/gaul/s3proxy/sftp/SftpBlobStoreTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2014-2026 Andrew Gaul <andrew@gaul.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gaul.s3proxy.sftp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.jclouds.ContextBuilder;
+import org.junit.Test;
+
+public final class SftpBlobStoreTest {
+    @Test
+    public void testProviderRegistration() {
+        var builder = ContextBuilder.newBuilder("sftp");
+        assertThat(builder).isNotNull();
+    }
+}


### PR DESCRIPTION
## Summary

- extend `LocalS3BackupClientSmokeTest` to cover the real backup-settings save flow in addition to the connectivity test
- allow the smoke test to run against an external endpoint for in-cluster validation
- keep the SFTP bridge profile upstream-style, with S3 auth credentials separate from backend SFTP credentials
- assert backup object layout under the bucket directory in `S3BackupSftpBridgeTest`
- document the S3 backup to SFTP bridge mapping and compatibility notes

## Why

The backup-client integration depends on both configuration-test and configuration-save API paths. The previous smoke coverage only exercised the connectivity test and missed the save endpoint behavior.

## Validation

- `mvn verify`
- `mvn test "-Dtest=Sftp*Test"`
- `mvn test -Dtest=S3BackupSftpBridgeTest,LocalS3BackupClientSmokeTest`

## Notes

- Local smoke remains opt-in and is skipped unless credentials are provided.
- Checksum validation guidance remains compatibility-focused and configurable.
