### PR TITLE
Bridge S3 backup clients to SFTP storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Maven Central hosts S3Proxy artifacts and the wiki has
 * rackspace-cloudfiles-uk and rackspace-cloudfiles-us
 * s3 (non-Amazon, alias for aws-s3-sdk)
 * s3-jclouds (non-Amazon S3 via jclouds, deprecated)
+* sftp (SFTP storage via Apache MINA SSHD)
 * transient (in-memory storage, alias for transient-nio2)
 * transient-nio2 (in-memory storage, recommended)
 * transient-jclouds (in-memory storage via jclouds, deprecated)

--- a/docs/SFTP.md
+++ b/docs/SFTP.md
@@ -1,0 +1,98 @@
+# SFTP
+
+Status: experimental
+
+The SFTP backend exposes an SFTP server as an S3Proxy storage backend through
+the jclouds `BlobStore` interface. It reuses the existing NIO.2 blobstore
+implementation over Apache MINA SSHD's SFTP filesystem provider.
+
+## Security
+
+The SFTP backend requires a pinned SFTP server host-key fingerprint. Set
+`jclouds.sftp.host-key` to the expected fingerprint, for example
+`SHA256:...`. S3Proxy rejects the SFTP connection if the server presents a
+different host key.
+
+Keep S3Proxy client credentials separate from SFTP credentials. S3 clients
+authenticate to S3Proxy with `s3proxy.identity` and `s3proxy.credential`; S3Proxy
+authenticates to the SFTP server with `jclouds.identity` and
+`jclouds.credential`.
+
+## Configuration
+
+Example:
+
+```
+s3proxy.authorization=aws-v2-or-v4
+s3proxy.endpoint=http://127.0.0.1:8080
+s3proxy.identity=local-identity
+s3proxy.credential=local-credential
+
+jclouds.provider=sftp
+jclouds.endpoint=sftp://127.0.0.1:2222/
+jclouds.identity=sftp-user
+jclouds.credential=sftp-password
+jclouds.sftp.basedir=/s3proxy
+jclouds.sftp.host-key=SHA256:...
+```
+
+If `jclouds.endpoint` omits a port, the backend uses SFTP port 22. The default
+`jclouds.sftp.basedir` is `/s3proxy`.
+
+You can usually get an OpenSSH-format SHA256 host-key fingerprint with:
+
+```
+ssh-keyscan -p 2222 127.0.0.1 | ssh-keygen -lf -
+```
+
+## Storage Mapping
+
+S3 buckets are first-level directories below `jclouds.sftp.basedir`. Object keys
+map to files below the bucket directory. The effective path mapping is:
+
+```
+<jclouds.sftp.basedir>/<bucket>/<object-key>
+```
+
+Example:
+
+```
+jclouds.sftp.basedir=/data/backups
+bucket=example-bucket
+object-key=backups/app/1000/db_dump.zip
+```
+
+Stored SFTP path:
+
+```
+/data/backups/example-bucket/backups/app/1000/db_dump.zip
+```
+
+The bucket name is therefore part of the SFTP path. For S3-compatible backup
+clients, configure the client bucket name to the directory name you want under
+`jclouds.sftp.basedir`.
+
+## Metadata
+
+The NIO.2 backend stores content metadata and user metadata in user extended
+attributes when the filesystem supports them. SFTP servers generally do not
+provide portable user extended attributes, so the SFTP backend treats them as
+optional.
+
+Object bytes are stored as regular SFTP files. Object size and last-modified
+values come from SFTP file attributes. S3 user metadata is not portable across
+SFTP servers.
+
+## Compatibility Profile
+
+The embedded SFTP test covers the common S3-compatible backup operation set:
+
+* create bucket;
+* upload payload and metadata objects;
+* `HEAD` payload objects;
+* `GET` payload and metadata objects;
+* list objects with a prefix;
+* delete objects and bucket.
+
+Broader S3 API compatibility should be validated against the target SFTP server
+before production use.

--- a/pom.xml
+++ b/pom.xml
@@ -424,6 +424,7 @@
     <opentelemetry-semconv.version>1.41.0</opentelemetry-semconv.version>
     <slf4j.version>2.0.17</slf4j.version>
     <shade.prefix>${project.groupId}.shaded</shade.prefix>
+    <sshd.version>2.17.1</sshd.version>
     <surefire.version>3.5.5</surefire.version>
   </properties>
 
@@ -563,6 +564,11 @@
       <groupId>org.apache.jclouds.driver</groupId>
       <artifactId>jclouds-slf4j</artifactId>
       <version>${jclouds.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.sshd</groupId>
+      <artifactId>sshd-sftp</artifactId>
+      <version>${sshd.version}</version>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>

--- a/src/main/java/org/gaul/s3proxy/nio2blob/AbstractNio2BlobStore.java
+++ b/src/main/java/org/gaul/s3proxy/nio2blob/AbstractNio2BlobStore.java
@@ -597,12 +597,12 @@ public abstract class AbstractNio2BlobStore extends BaseBlobStore {
                 throw new RuntimeException(ioe);
             }
 
-            var view = Files.getFileAttributeView(path, UserDefinedFileAttributeView.class);
+            var view = getXattrView(path);
             if (view != null) {
                 try {
                     writeCommonMetadataAttr(view, blob);
                     view.write(XATTR_CONTENT_MD5, ByteBuffer.wrap(DIRECTORY_MD5));
-                } catch (IOException ioe) {
+                } catch (IOException | UnsupportedOperationException ioe) {
                     logger.debug("xattrs not supported on {}", path);
                 }
             }
@@ -635,7 +635,7 @@ public abstract class AbstractNio2BlobStore extends BaseBlobStore {
                 throw returnResponseException(400);
             }
 
-            var view = Files.getFileAttributeView(tmpPath, UserDefinedFileAttributeView.class);
+            var view = getXattrView(tmpPath);
             if (view != null) {
                 try {
                     var eTag = actualHashCode.asBytes();
@@ -655,9 +655,8 @@ public abstract class AbstractNio2BlobStore extends BaseBlobStore {
                     for (var entry : blob.getMetadata().getUserMetadata().entrySet()) {
                         writeStringAttributeIfPresent(view, XATTR_USER_METADATA_PREFIX + entry.getKey(), entry.getValue());
                     }
-                } catch (IOException e) {
-                    // TODO:
-                    //logger.debug("xattrs not supported on %s", path);
+                } catch (IOException | UnsupportedOperationException e) {
+                    logger.debug("xattrs not supported on {}", tmpPath);
                 }
             }
 
@@ -1210,13 +1209,13 @@ public abstract class AbstractNio2BlobStore extends BaseBlobStore {
      * (e.g., Docker Desktop bind mounts via VirtioFS, some NFS/NAS mounts).
      */
     private static XattrState safeGetXattrs(Path path) {
-        var view = Files.getFileAttributeView(path, UserDefinedFileAttributeView.class);
+        var view = getXattrView(path);
         if (view == null) {
             return XattrState.EMPTY;
         }
         try {
             return new XattrState(view, Set.copyOf(view.list()));
-        } catch (IOException e) {
+        } catch (IOException | UnsupportedOperationException e) {
             logger.debug("xattrs not supported on {}", path);
             return XattrState.EMPTY;
         }
@@ -1226,6 +1225,16 @@ public abstract class AbstractNio2BlobStore extends BaseBlobStore {
         var sep = path.getFileSystem().getSeparator();
         var name = containerPath.relativize(path).toString();
         return sep.equals("/") ? name : name.replace(sep, "/");
+    }
+
+    private static UserDefinedFileAttributeView getXattrView(Path path) {
+        try {
+            return Files.getFileAttributeView(path,
+                    UserDefinedFileAttributeView.class);
+        } catch (UnsupportedOperationException uoe) {
+            logger.debug("xattrs not supported on {}", path);
+            return null;
+        }
     }
 
     private static void checkValidPath(Path container, Path path) {

--- a/src/main/java/org/gaul/s3proxy/sftp/SftpBlobStore.java
+++ b/src/main/java/org/gaul/s3proxy/sftp/SftpBlobStore.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2014-2026 Andrew Gaul <andrew@gaul.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gaul.s3proxy.sftp;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.base.Supplier;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+import org.apache.sshd.client.SshClient;
+import org.apache.sshd.common.config.keys.KeyUtils;
+import org.apache.sshd.sftp.client.fs.SftpFileSystemProvider;
+import org.gaul.s3proxy.nio2blob.AbstractNio2BlobStore;
+import org.jclouds.blobstore.BlobStoreContext;
+import org.jclouds.blobstore.util.BlobUtils;
+import org.jclouds.collect.Memoized;
+import org.jclouds.domain.Credentials;
+import org.jclouds.domain.Location;
+import org.jclouds.io.PayloadSlicer;
+import org.jclouds.lifecycle.Closer;
+import org.jclouds.providers.ProviderMetadata;
+
+@Singleton
+public final class SftpBlobStore extends AbstractNio2BlobStore {
+    private final SshClient client;
+    private final FileSystem fileSystem;
+
+    @Inject
+    SftpBlobStore(BlobStoreContext context, BlobUtils blobUtils,
+            Supplier<Location> defaultLocation,
+            @Memoized Supplier<Set<? extends Location>> locations,
+            PayloadSlicer slicer,
+            @org.jclouds.location.Provider Supplier<Credentials> creds,
+            ProviderMetadata provider,
+            Closer closer,
+            @Named(SftpBlobStoreApiMetadata.BASEDIR) String baseDir,
+            @Named(SftpBlobStoreApiMetadata.HOST_KEY) String hostKey) {
+        this(context, blobUtils, defaultLocation, locations, slicer, creds,
+                createRoot(provider, creds.get(), baseDir, hostKey));
+        closer.addToClose(client);
+        closer.addToClose(fileSystem);
+    }
+
+    private SftpBlobStore(BlobStoreContext context, BlobUtils blobUtils,
+            Supplier<Location> defaultLocation,
+            @Memoized Supplier<Set<? extends Location>> locations,
+            PayloadSlicer slicer,
+            Supplier<Credentials> creds,
+            Root root) {
+        super(context, blobUtils, defaultLocation, locations, slicer, creds,
+                root.path);
+        this.client = root.client;
+        this.fileSystem = root.fileSystem;
+    }
+
+    static int endpointPort(URI endpoint) {
+        int port = endpoint.getPort();
+        return port < 0 ? 22 : port;
+    }
+
+    private static Root createRoot(ProviderMetadata provider, Credentials creds,
+            String baseDir, String hostKey) {
+        var endpoint = URI.create(provider.getEndpoint());
+        int port = endpointPort(endpoint);
+        var uri = createFileSystemUri(endpoint.getHost(), port, creds);
+        SshClient client = null;
+        FileSystem fs = null;
+        try {
+            client = createClient(hostKey);
+            fs = new SftpFileSystemProvider(client).newFileSystem(uri,
+                    Map.of());
+            var root = fs.getPath(baseDir).normalize();
+            createDirectories(root);
+            return new Root(client, fs, root);
+        } catch (IOException ioe) {
+            closeQuietly(fs, ioe);
+            closeQuietly(client, ioe);
+            throw new UncheckedIOException(
+                    "Failed to initialize SFTP backend", ioe);
+        } catch (RuntimeException re) {
+            closeQuietly(fs, re);
+            closeQuietly(client, re);
+            throw re;
+        }
+    }
+
+    private static SshClient createClient(String expectedHostKey) {
+        var fingerprint = expectedHostKey == null ? "" :
+                expectedHostKey.trim();
+        if (fingerprint.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Missing required SFTP host key fingerprint property: " +
+                    SftpBlobStoreApiMetadata.HOST_KEY);
+        }
+        var client = SshClient.setUpDefaultClient();
+        try {
+            client.setServerKeyVerifier((session, remoteAddress, serverKey) ->
+                    Boolean.TRUE.equals(KeyUtils.checkFingerPrint(fingerprint,
+                            serverKey).getKey()));
+            client.start();
+        } catch (RuntimeException re) {
+            closeQuietly(client, re);
+            throw re;
+        }
+        return client;
+    }
+
+    private static URI createFileSystemUri(String host, int port,
+            Credentials creds) {
+        if (creds.identity == null || creds.identity.isBlank()) {
+            throw new IllegalArgumentException(
+                    "Missing required SFTP identity");
+        }
+        var userInfo = creds.credential == null ? creds.identity :
+                creds.identity + ":" + creds.credential;
+        try {
+            return new URI("sftp", userInfo, host, port, "/", null, null);
+        } catch (URISyntaxException use) {
+            throw new IllegalArgumentException(
+                    "Failed to create SFTP filesystem URI", use);
+        }
+    }
+
+    private static void createDirectories(Path root) throws IOException {
+        if (Files.exists(root)) {
+            return;
+        }
+        try {
+            Files.createDirectories(root);
+        } catch (FileAlreadyExistsException faee) {
+            // The target may appear between exists() and createDirectories().
+        }
+    }
+
+    private static void closeQuietly(Closeable closeable, Throwable throwable) {
+        if (closeable == null) {
+            return;
+        }
+        try {
+            closeable.close();
+        } catch (IOException closeException) {
+            throwable.addSuppressed(closeException);
+        }
+    }
+
+    private static final class Root {
+        private final SshClient client;
+        private final FileSystem fileSystem;
+        private final Path path;
+
+        private Root(SshClient client, FileSystem fileSystem, Path path) {
+            this.client = client;
+            this.fileSystem = fileSystem;
+            this.path = path;
+        }
+    }
+}

--- a/src/main/java/org/gaul/s3proxy/sftp/SftpBlobStoreApiMetadata.java
+++ b/src/main/java/org/gaul/s3proxy/sftp/SftpBlobStoreApiMetadata.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2014-2026 Andrew Gaul <andrew@gaul.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gaul.s3proxy.sftp;
+
+import java.net.URI;
+import java.util.Properties;
+import java.util.Set;
+
+import org.jclouds.blobstore.BlobStoreContext;
+import org.jclouds.reflect.Reflection2;
+import org.jclouds.rest.internal.BaseHttpApiMetadata;
+
+@SuppressWarnings("rawtypes")
+public final class SftpBlobStoreApiMetadata extends BaseHttpApiMetadata {
+    public static final String BASEDIR = "jclouds.sftp.basedir";
+    public static final String HOST_KEY = "jclouds.sftp.host-key";
+
+    public SftpBlobStoreApiMetadata() {
+        this(builder());
+    }
+
+    protected SftpBlobStoreApiMetadata(Builder builder) {
+        super(builder);
+    }
+
+    private static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return builder().fromApiMetadata(this);
+    }
+
+    public static Properties defaultProperties() {
+        Properties properties = BaseHttpApiMetadata.defaultProperties();
+        properties.setProperty(BASEDIR, "/s3proxy");
+        properties.setProperty(HOST_KEY, "");
+        return properties;
+    }
+
+    // Fake API client
+    private interface SftpBlobStoreClient {
+    }
+
+    public static final class Builder
+            extends BaseHttpApiMetadata.Builder<SftpBlobStoreClient, Builder> {
+        protected Builder() {
+            super(SftpBlobStoreClient.class);
+            id("sftp")
+                .name("SFTP Blobstore")
+                .identityName("Username")
+                .credentialName("Password")
+                .defaultEndpoint("sftp://127.0.0.1:22/")
+                .documentation(URI.create(
+                        "http://www.jclouds.org/documentation/userguide" +
+                        "/blobstore-guide"))
+                .defaultProperties(SftpBlobStoreApiMetadata.defaultProperties())
+                .view(Reflection2.typeToken(BlobStoreContext.class))
+                .defaultModules(Set.of(SftpBlobStoreContextModule.class));
+        }
+
+        @Override
+        public SftpBlobStoreApiMetadata build() {
+            return new SftpBlobStoreApiMetadata(this);
+        }
+
+        @Override
+        protected Builder self() {
+            return this;
+        }
+    }
+}

--- a/src/main/java/org/gaul/s3proxy/sftp/SftpBlobStoreContextModule.java
+++ b/src/main/java/org/gaul/s3proxy/sftp/SftpBlobStoreContextModule.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2014-2026 Andrew Gaul <andrew@gaul.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gaul.s3proxy.sftp;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Scopes;
+
+import org.jclouds.blobstore.BlobStore;
+import org.jclouds.blobstore.attr.ConsistencyModel;
+
+public final class SftpBlobStoreContextModule extends AbstractModule {
+    @Override
+    protected void configure() {
+        bind(ConsistencyModel.class).toInstance(ConsistencyModel.EVENTUAL);
+        bind(BlobStore.class).to(SftpBlobStore.class).in(Scopes.SINGLETON);
+    }
+}

--- a/src/main/java/org/gaul/s3proxy/sftp/SftpBlobStoreProviderMetadata.java
+++ b/src/main/java/org/gaul/s3proxy/sftp/SftpBlobStoreProviderMetadata.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2014-2026 Andrew Gaul <andrew@gaul.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gaul.s3proxy.sftp;
+
+import java.util.Properties;
+
+import com.google.auto.service.AutoService;
+
+import org.jclouds.providers.ProviderMetadata;
+import org.jclouds.providers.internal.BaseProviderMetadata;
+
+@AutoService(ProviderMetadata.class)
+public final class SftpBlobStoreProviderMetadata extends BaseProviderMetadata {
+    public SftpBlobStoreProviderMetadata() {
+        super(builder());
+    }
+
+    public SftpBlobStoreProviderMetadata(Builder builder) {
+        super(builder);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return builder().fromProviderMetadata(this);
+    }
+
+    public static Properties defaultProperties() {
+        return new Properties();
+    }
+
+    public static final class Builder extends BaseProviderMetadata.Builder {
+        protected Builder() {
+            id("sftp")
+                .name("SFTP blobstore")
+                .apiMetadata(new SftpBlobStoreApiMetadata())
+                .endpoint("sftp://127.0.0.1:22/")
+                .defaultProperties(
+                        SftpBlobStoreProviderMetadata.defaultProperties());
+        }
+
+        @Override
+        public SftpBlobStoreProviderMetadata build() {
+            return new SftpBlobStoreProviderMetadata(this);
+        }
+
+        @Override
+        public Builder fromProviderMetadata(ProviderMetadata in) {
+            super.fromProviderMetadata(in);
+            return this;
+        }
+    }
+}

--- a/src/test/java/org/gaul/s3proxy/S3BackupSftpBridgeTest.java
+++ b/src/test/java/org/gaul/s3proxy/S3BackupSftpBridgeTest.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2014-2026 Andrew Gaul <andrew@gaul.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gaul.s3proxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.sshd.common.config.keys.KeyUtils;
+import org.apache.sshd.common.file.virtualfs.VirtualFileSystemFactory;
+import org.apache.sshd.common.keyprovider.KeyIdentityProvider;
+import org.apache.sshd.server.SshServer;
+import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
+import org.apache.sshd.sftp.server.SftpSubsystemFactory;
+import org.gaul.s3proxy.sftp.SftpBlobStoreApiMetadata;
+import org.jclouds.Constants;
+import org.jclouds.ContextBuilder;
+import org.jclouds.blobstore.BlobStoreContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.core.checksums.RequestChecksumCalculation;
+import software.amazon.awssdk.core.checksums.ResponseChecksumValidation;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3Configuration;
+
+public final class S3BackupSftpBridgeTest {
+    private static final String SFTP_USER = "sftp-user";
+    private static final String SFTP_PASSWORD = "sftp:p@ss/word#%";
+    private static final String S3_IDENTITY = "local-identity";
+    private static final String S3_CREDENTIAL = "local-credential";
+    private static final String BASEDIR = "/s3proxy-test";
+
+    private SshServer sshServer;
+    private BlobStoreContext context;
+    private S3Proxy s3Proxy;
+    private S3AsyncClient s3Client;
+    @TempDir
+    private Path sftpRoot;
+    @TempDir
+    private Path tempDir;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        sshServer = SshServer.setUpDefaultServer();
+        sshServer.setHost("127.0.0.1");
+        sshServer.setPort(0);
+        var hostKeyProvider = new SimpleGeneratorHostKeyProvider(
+                tempDir.resolve("hostkey.ser"));
+        sshServer.setKeyPairProvider(hostKeyProvider);
+        sshServer.setPasswordAuthenticator((username, password, session) ->
+                SFTP_USER.equals(username) && SFTP_PASSWORD.equals(password));
+        sshServer.setFileSystemFactory(new VirtualFileSystemFactory(sftpRoot));
+        sshServer.setSubsystemFactories(List.of(
+                new SftpSubsystemFactory.Builder().build()));
+        sshServer.start();
+
+        var properties = new Properties();
+        properties.setProperty(Constants.PROPERTY_ENDPOINT,
+                "sftp://127.0.0.1:" + sshServer.getPort() + "/");
+        properties.setProperty(SftpBlobStoreApiMetadata.BASEDIR, BASEDIR);
+        properties.setProperty(SftpBlobStoreApiMetadata.HOST_KEY,
+                hostKeyFingerprint(hostKeyProvider));
+        context = ContextBuilder.newBuilder("sftp")
+                .credentials(SFTP_USER, SFTP_PASSWORD)
+                .overrides(properties)
+                .build(BlobStoreContext.class);
+
+        s3Proxy = S3Proxy.builder()
+                .endpoint(URI.create("http://127.0.0.1:0"))
+                .awsAuthentication(AuthenticationType.AWS_V2_OR_V4,
+                        S3_IDENTITY, S3_CREDENTIAL)
+                .blobStore(context.getBlobStore())
+                .ignoreUnknownHeaders(true)
+                .build();
+        s3Proxy.start();
+
+        s3Client = S3AsyncClient.builder()
+                .multipartEnabled(true)
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(S3_IDENTITY, S3_CREDENTIAL)))
+                .region(Region.US_EAST_1)
+                .endpointOverride(
+                        URI.create("http://127.0.0.1:" + s3Proxy.getPort()))
+                .requestChecksumCalculation(
+                        RequestChecksumCalculation.WHEN_REQUIRED)
+                .responseChecksumValidation(
+                        ResponseChecksumValidation.WHEN_REQUIRED)
+                .serviceConfiguration(S3Configuration.builder()
+                        .pathStyleAccessEnabled(true)
+                        .chunkedEncodingEnabled(false)
+                        .build())
+                .build();
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        if (s3Client != null) {
+            s3Client.close();
+        }
+        if (s3Proxy != null) {
+            s3Proxy.stop();
+        }
+        if (context != null) {
+            context.close();
+        }
+        if (sshServer != null) {
+            sshServer.stop();
+        }
+    }
+
+    @Test
+    public void testS3BackupOperationProfile() throws Exception {
+        var bucket = "s3-backup";
+        var snapshotPayload = "backups/snapshot/100/snapshot.zip";
+        var snapshotEntry = "backups/snapshot/100/entry.txt";
+        var appPayload = "backups/app/1000/db_dump.zip";
+        var appEntry = "backups/app/1000/entry.txt";
+
+        get(s3Client.createBucket(request -> request.bucket(bucket)));
+        putObject(bucket, snapshotPayload, bytes(1024 * 1024));
+        putObject(bucket, snapshotEntry, "snapshot-entry".getBytes(
+                StandardCharsets.UTF_8));
+        putObject(bucket, appPayload, bytes(2 * 1024 * 1024));
+        putObject(bucket, appEntry, "app-entry".getBytes(StandardCharsets.UTF_8));
+
+        assertThat(get(s3Client.headObject(request -> request.bucket(bucket)
+                .key(snapshotPayload))).contentLength()).isEqualTo(1024 * 1024);
+        assertThat(get(s3Client.headObject(request -> request.bucket(bucket)
+                .key(appPayload))).contentLength()).isEqualTo(2 * 1024 * 1024);
+        assertThat(get(s3Client.getObject(request -> request.bucket(bucket)
+                .key(snapshotPayload), AsyncResponseTransformer.toBytes()))
+                .asByteArray()).isEqualTo(bytes(1024 * 1024));
+        assertThat(get(s3Client.getObject(request -> request.bucket(bucket)
+                .key(appPayload), AsyncResponseTransformer.toBytes()))
+                .asByteArray()).isEqualTo(bytes(2 * 1024 * 1024));
+        assertThat(get(s3Client.getObject(request -> request.bucket(bucket)
+                .key(snapshotEntry), AsyncResponseTransformer.toBytes()))
+                .asUtf8String()).isEqualTo("snapshot-entry");
+        assertThat(get(s3Client.getObject(request -> request.bucket(bucket)
+                .key(appEntry), AsyncResponseTransformer.toBytes()))
+                .asUtf8String()).isEqualTo("app-entry");
+
+        var snapshotKeys = get(s3Client.listObjectsV2(request -> request
+                .bucket(bucket)
+                .prefix("backups/snapshot/"))).contents();
+        assertThat(snapshotKeys).extracting(object -> object.key())
+                .containsExactlyInAnyOrder(snapshotPayload, snapshotEntry);
+
+        get(s3Client.deleteObject(request -> request.bucket(bucket)
+                .key(snapshotEntry)));
+        get(s3Client.deleteObject(request -> request.bucket(bucket)
+                .key(snapshotPayload)));
+        get(s3Client.deleteObject(request -> request.bucket(bucket)
+                .key(appEntry)));
+        get(s3Client.deleteObject(request -> request.bucket(bucket)
+                .key(appPayload)));
+        get(s3Client.deleteBucket(request -> request.bucket(bucket)));
+    }
+
+    private void putObject(String bucket, String key, byte[] content)
+            throws Exception {
+        get(s3Client.putObject(request -> request.bucket(bucket).key(key),
+                AsyncRequestBody.fromBytes(content)));
+    }
+
+    private static <T> T get(CompletableFuture<T> future) throws Exception {
+        return future.get(30, TimeUnit.SECONDS);
+    }
+
+    private static byte[] bytes(int size) {
+        var bytes = new byte[size];
+        for (int i = 0; i < size; i++) {
+            bytes[i] = (byte) (i & 0xff);
+        }
+        return bytes;
+    }
+
+    private static String hostKeyFingerprint(KeyIdentityProvider provider)
+            throws Exception {
+        return KeyUtils.getFingerPrint(provider.loadKeys(null).iterator()
+                .next().getPublic());
+    }
+}

--- a/src/test/java/org/gaul/s3proxy/sftp/SftpBlobStoreTest.java
+++ b/src/test/java/org/gaul/s3proxy/sftp/SftpBlobStoreTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2014-2026 Andrew Gaul <andrew@gaul.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gaul.s3proxy.sftp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Properties;
+
+import org.apache.sshd.common.config.keys.KeyUtils;
+import org.apache.sshd.common.file.virtualfs.VirtualFileSystemFactory;
+import org.apache.sshd.common.keyprovider.KeyIdentityProvider;
+import org.apache.sshd.server.SshServer;
+import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
+import org.apache.sshd.sftp.server.SftpSubsystemFactory;
+import org.assertj.core.api.Assertions;
+import org.jclouds.Constants;
+import org.jclouds.ContextBuilder;
+import org.jclouds.blobstore.BlobStoreContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public final class SftpBlobStoreTest {
+    private static final String SFTP_USER = "sftp-user";
+    private static final String SFTP_PASSWORD = "sftp:p@ss/word#%";
+    private static final String BASEDIR = "/s3proxy-test";
+
+    private SshServer sshServer;
+
+    @TempDir
+    private Path sftpRoot;
+    @TempDir
+    private Path tempDir;
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        if (sshServer != null) {
+            sshServer.stop();
+        }
+    }
+
+    @Test
+    public void testDefaultPort() {
+        assertThat(SftpBlobStore.endpointPort(URI.create("sftp://example.com/")))
+                .isEqualTo(22);
+        assertThat(SftpBlobStore.endpointPort(
+                URI.create("sftp://example.com:2022/"))).isEqualTo(2022);
+    }
+
+    @Test
+    public void testProviderRegistrationWithSpecialCharacterPassword()
+            throws Exception {
+        var hostKeyProvider = startSftpServer();
+
+        try (BlobStoreContext context = buildContext(hostKeyFingerprint(
+                hostKeyProvider))) {
+            var blobStore = context.getBlobStore();
+            var bucket = "bucket";
+            var key = "object.txt";
+            blobStore.createContainerInLocation(null, bucket);
+            blobStore.putBlob(bucket, blobStore.blobBuilder(key)
+                    .payload("value")
+                    .contentLength(5)
+                    .build());
+
+            try (var input = blobStore.getBlob(bucket, key).getPayload()
+                    .openStream()) {
+                assertThat(new String(input.readAllBytes(),
+                        StandardCharsets.UTF_8)).isEqualTo("value");
+            }
+        }
+    }
+
+    @Test
+    public void testRejectsMismatchedHostKey() throws Exception {
+        startSftpServer();
+
+        Assertions.assertThatThrownBy(() -> buildContext(
+                "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"))
+                .hasStackTraceContaining("Server key did not validate");
+    }
+
+    private BlobStoreContext buildContext(String hostKey) {
+        var properties = new Properties();
+        properties.setProperty(Constants.PROPERTY_ENDPOINT,
+                "sftp://127.0.0.1:" + sshServer.getPort() + "/");
+        properties.setProperty(SftpBlobStoreApiMetadata.BASEDIR, BASEDIR);
+        properties.setProperty(SftpBlobStoreApiMetadata.HOST_KEY, hostKey);
+        return ContextBuilder.newBuilder("sftp")
+                .credentials(SFTP_USER, SFTP_PASSWORD)
+                .overrides(properties)
+                .build(BlobStoreContext.class);
+    }
+
+    private KeyIdentityProvider startSftpServer() throws Exception {
+        sshServer = SshServer.setUpDefaultServer();
+        sshServer.setHost("127.0.0.1");
+        sshServer.setPort(0);
+        var hostKeyProvider = new SimpleGeneratorHostKeyProvider(
+                tempDir.resolve("hostkey.ser"));
+        sshServer.setKeyPairProvider(hostKeyProvider);
+        sshServer.setPasswordAuthenticator((username, password, session) ->
+                SFTP_USER.equals(username) && SFTP_PASSWORD.equals(password));
+        sshServer.setFileSystemFactory(new VirtualFileSystemFactory(sftpRoot));
+        sshServer.setSubsystemFactories(List.of(
+                new SftpSubsystemFactory.Builder().build()));
+        sshServer.start();
+        return hostKeyProvider;
+    }
+
+    private static String hostKeyFingerprint(KeyIdentityProvider provider)
+            throws Exception {
+        return KeyUtils.getFingerPrint(provider.loadKeys(null).iterator()
+                .next().getPublic());
+    }
+}


### PR DESCRIPTION
## Summary

Adds an SFTP-backed BlobStore provider so S3-compatible clients can write through S3Proxy to SFTP storage.

## Details
- Reuses the existing NIO.2 BlobStore implementation over Apache MINA SSHD SFTP.
- Keeps S3Proxy client credentials separate from SFTP backend credentials.
- Requires a pinned SFTP host-key fingerprint via `jclouds.sftp.host-key`.
- Maps objects to `<jclouds.sftp.basedir>/<bucket>/<object-key>`.
- Closes the SFTP FileSystem and SSH client through the jclouds context lifecycle.

## Validation
- `mvn verify`
- `mvn test -Dtest=SftpBlobStoreTest,S3BackupSftpBridgeTest`