### PR TITLE
Return RuntimeException from translate instead of throwing

### DIFF
--- a/src/main/java/org/gaul/s3proxy/awssdk/AwsS3SdkBlobStore.java
+++ b/src/main/java/org/gaul/s3proxy/awssdk/AwsS3SdkBlobStore.java
@@ -202,8 +202,7 @@ public final class AwsS3SdkBlobStore extends BaseBlobStore {
             }
             return new PageSetImpl<StorageMetadata>(set.build(), null);
         } catch (S3Exception e) {
-            translateAndRethrowException(e, null, null);
-            throw e;
+            throw translate(e, null, null);
         }
     }
 
@@ -272,8 +271,7 @@ public final class AwsS3SdkBlobStore extends BaseBlobStore {
         } catch (NoSuchBucketException e) {
             throw new ContainerNotFoundException(container, e.getMessage());
         } catch (S3Exception e) {
-            translateAndRethrowException(e, container, null);
-            throw e;
+            throw translate(e, container, null);
         }
     }
 
@@ -336,8 +334,7 @@ public final class AwsS3SdkBlobStore extends BaseBlobStore {
                             "Bucket already exists: " + container, e);
                 }
             }
-            translateAndRethrowException(e, container, null);
-            throw e;
+            throw translate(e, container, null);
         }
     }
 
@@ -351,8 +348,7 @@ public final class AwsS3SdkBlobStore extends BaseBlobStore {
         } catch (NoSuchBucketException e) {
             // Already deleted, ignore
         } catch (S3Exception e) {
-            translateAndRethrowException(e, container, null);
-            throw e;
+            throw translate(e, container, null);
         }
     }
 
@@ -476,8 +472,7 @@ public final class AwsS3SdkBlobStore extends BaseBlobStore {
                 throw new HttpResponseException(
                         new HttpCommand(request), responseBuilder.build(), e);
             }
-            translateAndRethrowException(e, container, key);
-            throw e;
+            throw translate(e, container, key);
         }
     }
 
@@ -568,9 +563,7 @@ public final class AwsS3SdkBlobStore extends BaseBlobStore {
         } catch (IOException e) {
             throw new RuntimeException("Failed to read blob payload", e);
         } catch (S3Exception e) {
-            translateAndRethrowException(e, container,
-                    blob.getMetadata().getName());
-            throw e;
+            throw translate(e, container, blob.getMetadata().getName());
         }
     }
 
@@ -621,8 +614,7 @@ public final class AwsS3SdkBlobStore extends BaseBlobStore {
         } catch (NoSuchBucketException e) {
             throw new ContainerNotFoundException(fromContainer, e.getMessage());
         } catch (S3Exception e) {
-            translateAndRethrowException(e, fromContainer, fromName);
-            throw e;
+            throw translate(e, fromContainer, fromName);
         }
     }
 
@@ -667,8 +659,7 @@ public final class AwsS3SdkBlobStore extends BaseBlobStore {
             if (e.statusCode() == 404) {
                 return null;
             }
-            translateAndRethrowException(e, container, key);
-            throw e;
+            throw translate(e, container, key);
         }
     }
 
@@ -715,8 +706,7 @@ public final class AwsS3SdkBlobStore extends BaseBlobStore {
         } catch (NoSuchBucketException e) {
             throw new ContainerNotFoundException(container, e.getMessage());
         } catch (S3Exception e) {
-            translateAndRethrowException(e, container, null);
-            throw e;
+            throw translate(e, container, null);
         }
     }
 
@@ -794,8 +784,7 @@ public final class AwsS3SdkBlobStore extends BaseBlobStore {
         } catch (NoSuchBucketException e) {
             throw new ContainerNotFoundException(container, e.getMessage());
         } catch (S3Exception e) {
-            translateAndRethrowException(e, container, key);
-            throw e;
+            throw translate(e, container, key);
         }
     }
 
@@ -851,8 +840,7 @@ public final class AwsS3SdkBlobStore extends BaseBlobStore {
         } catch (NoSuchBucketException e) {
             throw new ContainerNotFoundException(container, e.getMessage());
         } catch (S3Exception e) {
-            translateAndRethrowException(e, container, blobMetadata.getName());
-            throw e;
+            throw translate(e, container, blobMetadata.getName());
         }
     }
 
@@ -902,8 +890,7 @@ public final class AwsS3SdkBlobStore extends BaseBlobStore {
             applyMultipartAclIfNeeded(mpu);
             return response.eTag();
         } catch (S3Exception e) {
-            translateAndRethrowException(e, mpu.containerName(), mpu.blobName());
-            throw e;
+            throw translate(e, mpu.containerName(), mpu.blobName());
         }
     }
 
@@ -929,8 +916,7 @@ public final class AwsS3SdkBlobStore extends BaseBlobStore {
         } catch (IOException e) {
             throw new RuntimeException("Failed to upload part", e);
         } catch (S3Exception e) {
-            translateAndRethrowException(e, mpu.containerName(), mpu.blobName());
-            throw e;
+            throw translate(e, mpu.containerName(), mpu.blobName());
         }
     }
 
@@ -964,8 +950,7 @@ public final class AwsS3SdkBlobStore extends BaseBlobStore {
             if (e.statusCode() == 404) {
                 return ImmutableList.of();
             }
-            translateAndRethrowException(e, mpu.containerName(), mpu.blobName());
-            throw e;
+            throw translate(e, mpu.containerName(), mpu.blobName());
         }
     }
 
@@ -1003,8 +988,7 @@ public final class AwsS3SdkBlobStore extends BaseBlobStore {
         } catch (NoSuchBucketException e) {
             throw new ContainerNotFoundException(container, e.getMessage());
         } catch (S3Exception e) {
-            translateAndRethrowException(e, container, null);
-            throw e;
+            throw translate(e, container, null);
         }
     }
 
@@ -1124,22 +1108,22 @@ public final class AwsS3SdkBlobStore extends BaseBlobStore {
         return builder.build();
     }
 
-    private void translateAndRethrowException(S3Exception e,
+    private RuntimeException translate(S3Exception e,
             @Nullable String container, @Nullable String key) {
         if (container != null && e.statusCode() == 404) {
             String errorCode = e.awsErrorDetails().errorCode();
             if ("NoSuchBucket".equals(errorCode)) {
-                throw new ContainerNotFoundException(container, e.getMessage());
+                return new ContainerNotFoundException(container, e.getMessage());
             } else if ("NoSuchKey".equals(errorCode)) {
                 if (key == null) {
-                    throw new ContainerNotFoundException(container, e.getMessage());
+                    return new ContainerNotFoundException(container, e.getMessage());
                 }
-                throw new KeyNotFoundException(container, key, e.getMessage());
+                return new KeyNotFoundException(container, key, e.getMessage());
             }
             if (key != null) {
-                throw new KeyNotFoundException(container, key, e.getMessage());
+                return new KeyNotFoundException(container, key, e.getMessage());
             } else {
-                throw new ContainerNotFoundException(container, e.getMessage());
+                return new ContainerNotFoundException(container, e.getMessage());
             }
         }
         var request = HttpRequest.builder()
@@ -1155,7 +1139,7 @@ public final class AwsS3SdkBlobStore extends BaseBlobStore {
                     .ifPresent(etag -> responseBuilder.addHeader(HttpHeaders.ETAG, etag));
         }
 
-        throw new HttpResponseException(
+        return new HttpResponseException(
                 new HttpCommand(request), responseBuilder.build(), e);
     }
 

--- a/src/main/java/org/gaul/s3proxy/azureblob/AzureBlobStore.java
+++ b/src/main/java/org/gaul/s3proxy/azureblob/AzureBlobStore.java
@@ -188,8 +188,7 @@ public final class AzureBlobStore extends BaseBlobStore {
                     options.getDelimiter(), azureOptions, /*timeout=*/ null)
                     .iterableByPage(marker).iterator().next();
         } catch (BlobStorageException bse) {
-            translateAndRethrowException(bse, container, /*key=*/ null);
-            throw bse;
+            throw translate(bse, container, /*key=*/ null);
         }
         for (var blob : page.getValue()) {
             var properties = blob.getProperties();
@@ -248,8 +247,7 @@ public final class AzureBlobStore extends BaseBlobStore {
             default -> false;
             };
         } catch (BlobStorageException bse) {
-            translateAndRethrowException(bse, container, /*key=*/ null);
-            throw bse;
+            throw translate(bse, container, /*key=*/ null);
         }
     }
 
@@ -330,7 +328,6 @@ public final class AzureBlobStore extends BaseBlobStore {
         try {
             blobStream = client.openInputStream(azureRange, conditions);
         } catch (BlobStorageException bse) {
-            translateAndRethrowException(bse, container, key);
             if (bse.getStatusCode() ==
                     Status.REQUESTED_RANGE_NOT_SATISFIABLE.getStatusCode()) {
                 throw new HttpResponseException(
@@ -340,7 +337,7 @@ public final class AzureBlobStore extends BaseBlobStore {
                                 .getStatusCode())
                         .build());
             }
-            throw bse;
+            throw translate(bse, container, key);
         }
         var properties = blobStream.getProperties();
         var expires = properties.getExpiresOn();
@@ -435,10 +432,8 @@ public final class AzureBlobStore extends BaseBlobStore {
                     .getProperties()
                     .getETag();
         } catch (IOException ioe) {
-            var cause = ioe.getCause();
-            if (cause instanceof BlobStorageException bse) {
-                translateAndRethrowException(
-                        bse, container, /*key=*/ null);
+            if (ioe.getCause() instanceof BlobStorageException bse) {
+                throw translate(bse, container, /*key=*/ null);
             }
             throw new RuntimeException(ioe);
         }
@@ -541,8 +536,7 @@ public final class AzureBlobStore extends BaseBlobStore {
             if (bse.getErrorCode().equals(BlobErrorCode.BLOB_NOT_FOUND)) {
                 return null;
             }
-            translateAndRethrowException(bse, container, /*key=*/ null);
-            throw bse;
+            throw translate(bse, container, /*key=*/ null);
         }
         return new BlobMetadataImpl(/*id=*/ null, key, /*location=*/ null,
                 /*uri=*/ null, properties.getETag(),
@@ -569,8 +563,7 @@ public final class AzureBlobStore extends BaseBlobStore {
                     ContainerAccess.PUBLIC_READ :
                     ContainerAccess.PRIVATE;
         } catch (BlobStorageException bse) {
-            translateAndRethrowException(bse, container, /*key=*/ null);
-            throw bse;
+            throw translate(bse, container, /*key=*/ null);
         }
     }
 
@@ -601,8 +594,7 @@ public final class AzureBlobStore extends BaseBlobStore {
                 throw new ContainerNotFoundException(container, "");
             }
         } catch (BlobStorageException bse) {
-            translateAndRethrowException(bse, container, /*key=*/ null);
-            throw bse;
+            throw translate(bse, container, /*key=*/ null);
         }
 
         var userMetadata = blobMetadata.getUserMetadata();
@@ -814,7 +806,7 @@ public final class AzureBlobStore extends BaseBlobStore {
                 throw new IllegalArgumentException(
                         "Conflict during commit: " + bse.getMessage(), bse);
             } else if (bse.getStatusCode() == 412) {
-                translateAndRethrowException(bse, mpu.containerName(), targetBlobName);
+                throw translate(bse, mpu.containerName(), targetBlobName);
             }
             throw bse;
         }
@@ -919,10 +911,7 @@ public final class AzureBlobStore extends BaseBlobStore {
             }
 
         } catch (BlobStorageException bse) {
-            translateAndRethrowException(bse, mpu.containerName(), mpu.blobName());
-            throw new RuntimeException(
-                    "Failed to upload part %d for blob '%s' in container '%s': %s".formatted(
-                    partNumber, mpu.blobName(), mpu.containerName(), bse.getMessage()), bse);
+            throw translate(bse, mpu.containerName(), mpu.blobName());
         } catch (IOException ioe) {
             throw new RuntimeException(
                     "Failed to upload part %d for blob '%s' in container '%s': %s".formatted(
@@ -1148,20 +1137,20 @@ public final class AzureBlobStore extends BaseBlobStore {
     }
 
     /**
-     * Translate BlobStorageException to a jclouds exception.  Throws if
-     * translated otherwise returns.
+     * Translate BlobStorageException to a jclouds exception, returning the
+     * original BlobStorageException unchanged if no translation applies.
      */
-    private void translateAndRethrowException(BlobStorageException bse,
+    private RuntimeException translate(BlobStorageException bse,
             String container, @Nullable String key) {
         var code = bse.getErrorCode();
         if (code.equals(BlobErrorCode.BLOB_NOT_FOUND)) {
             var exception = new KeyNotFoundException(container, key, "");
             exception.initCause(bse);
-            throw exception;
+            return exception;
         } else if (code.equals(BlobErrorCode.CONTAINER_NOT_FOUND)) {
             var exception = new ContainerNotFoundException(container, "");
             exception.initCause(bse);
-            throw exception;
+            return exception;
         } else if (code.equals(BlobErrorCode.CONDITION_NOT_MET)) {
             var request = HttpRequest.builder()
                     .method("GET")
@@ -1170,7 +1159,7 @@ public final class AzureBlobStore extends BaseBlobStore {
             var response = HttpResponse.builder()
                     .statusCode(Status.PRECONDITION_FAILED.getStatusCode())
                     .build();
-            throw new HttpResponseException(
+            return new HttpResponseException(
                     new HttpCommand(request), response, bse);
         } else if (code.equals(BlobErrorCode.BLOB_ALREADY_EXISTS)) {
             var request = HttpRequest.builder()
@@ -1180,7 +1169,7 @@ public final class AzureBlobStore extends BaseBlobStore {
             var response = HttpResponse.builder()
                     .statusCode(Status.PRECONDITION_FAILED.getStatusCode())
                     .build();
-            throw new HttpResponseException(
+            return new HttpResponseException(
                     new HttpCommand(request), response, bse);
         } else if (code.equals(BlobErrorCode.INVALID_OPERATION)) {
             var request = HttpRequest.builder()
@@ -1190,11 +1179,12 @@ public final class AzureBlobStore extends BaseBlobStore {
             var response = HttpResponse.builder()
                     .statusCode(Status.BAD_REQUEST.getStatusCode())
                     .build();
-            throw new HttpResponseException(
+            return new HttpResponseException(
                     new HttpCommand(request), response, bse);
         } else if (bse.getErrorCode().equals(BlobErrorCode.INVALID_RESOURCE_NAME)) {
-            throw new IllegalArgumentException(
+            return new IllegalArgumentException(
                     "Invalid container name", bse);
         }
+        return bse;
     }
 }

--- a/src/main/java/org/gaul/s3proxy/gcloudsdk/GCloudBlobStore.java
+++ b/src/main/java/org/gaul/s3proxy/gcloudsdk/GCloudBlobStore.java
@@ -186,8 +186,7 @@ public final class GCloudBlobStore extends BaseBlobStore {
             page = storage.list(container,
                     gcsOptions.toArray(new BlobListOption[0]));
         } catch (StorageException se) {
-            translateAndRethrowException(se, container, null);
-            throw se;
+            throw translate(se, container, null);
         }
 
         var set = ImmutableSet.<StorageMetadata>builder();
@@ -314,8 +313,7 @@ public final class GCloudBlobStore extends BaseBlobStore {
             gcsBlob = storage.get(BlobId.of(container, key),
                     gcsOptions.toArray(new BlobGetOption[0]));
         } catch (StorageException se) {
-            translateAndRethrowException(se, container, key);
-            throw se;
+            throw translate(se, container, key);
         }
         if (gcsBlob == null) {
             throw new KeyNotFoundException(container, key, "");
@@ -442,8 +440,7 @@ public final class GCloudBlobStore extends BaseBlobStore {
                     writeOptions.toArray(new BlobWriteOption[0]));
             return gcsBlob.getEtag();
         } catch (StorageException se) {
-            translateAndRethrowException(se, container, null);
-            throw se;
+            throw translate(se, container, null);
         } catch (IOException ioe) {
             throw new RuntimeException(ioe);
         }
@@ -492,8 +489,7 @@ public final class GCloudBlobStore extends BaseBlobStore {
             var result = storage.copy(copyRequest);
             return result.getResult().getEtag();
         } catch (StorageException se) {
-            translateAndRethrowException(se, fromContainer, fromName);
-            throw se;
+            throw translate(se, fromContainer, fromName);
         }
     }
 
@@ -517,8 +513,7 @@ public final class GCloudBlobStore extends BaseBlobStore {
             if (se.getCode() == 404) {
                 return null;
             }
-            translateAndRethrowException(se, container, null);
-            throw se;
+            throw translate(se, container, null);
         }
         if (gcsBlob == null) {
             return null;
@@ -886,13 +881,7 @@ public final class GCloudBlobStore extends BaseBlobStore {
                 }
             }
         } catch (StorageException se) {
-            translateAndRethrowException(se, mpu.containerName(),
-                    mpu.blobName());
-            throw new RuntimeException((
-                    "Failed to upload part %d for blob '%s' in " +
-                    "container '%s': %s").formatted(
-                    partNumber, mpu.blobName(), mpu.containerName(),
-                    se.getMessage()), se);
+            throw translate(se, mpu.containerName(), mpu.blobName());
         } catch (IOException ioe) {
             throw new RuntimeException((
                     "Failed to upload part %d for blob '%s' in " +
@@ -1056,21 +1045,22 @@ public final class GCloudBlobStore extends BaseBlobStore {
     }
 
     /**
-     * Translate StorageException to jclouds exceptions.
+     * Translate StorageException to a jclouds exception, returning the
+     * original StorageException unchanged if no translation applies.
      */
-    private static void translateAndRethrowException(StorageException se,
+    private static RuntimeException translate(StorageException se,
             String container, @Nullable String key) {
         switch (se.getCode()) {
         case 404 -> {
             if (key != null) {
                 var keyEx = new KeyNotFoundException(container, key, "");
                 keyEx.initCause(se);
-                throw keyEx;
+                return keyEx;
             } else {
                 var containerEx = new ContainerNotFoundException(
                         container, "");
                 containerEx.initCause(se);
-                throw containerEx;
+                return containerEx;
             }
         }
         case 412 -> {
@@ -1081,10 +1071,11 @@ public final class GCloudBlobStore extends BaseBlobStore {
             var response = HttpResponse.builder()
                     .statusCode(412)
                     .build();
-            throw new HttpResponseException(
+            return new HttpResponseException(
                     new HttpCommand(request), response, se);
         }
         default -> { }
         }
+        return se;
     }
 }


### PR DESCRIPTION
Each backend's exception translator was a void method that always threw, leaving every caller with a dead "throw e;" line to satisfy the compiler.  Convert the helpers to return a RuntimeException so callers can write "throw translate(e, ...)" directly.  Azure and GCloud now return the original exception in the fall-through case, which eliminates the silent-no-op behavior and the defensive RuntimeException wrapping that compensated for it.