### PR TITLE
Bump jackson-bom from 2.21.3 to 3.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -453,9 +453,9 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>com.fasterxml.jackson</groupId>
+        <groupId>tools.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
-        <version>2.21.3</version>
+        <version>3.1.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -564,7 +564,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <groupId>tools.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-xml</artifactId>
     </dependency>
     <dependency>

--- a/src/main/java/org/gaul/s3proxy/AccessControlPolicy.java
+++ b/src/main/java/org/gaul/s3proxy/AccessControlPolicy.java
@@ -18,8 +18,8 @@ package org.gaul.s3proxy;
 
 import java.util.Collection;
 
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 /** Represent an Amazon AccessControlPolicy for a container or object. */
 record AccessControlPolicy(
@@ -42,8 +42,9 @@ record AccessControlPolicy(
                 @JacksonXmlProperty(localName = "Permission") String permission) {
 
             record Grantee(
-                    @JacksonXmlProperty(namespace = "xsi", localName = "type",
-                            isAttribute = true) String type,
+                    @JacksonXmlProperty(
+                            namespace = "http://www.w3.org/2001/XMLSchema-instance",
+                            localName = "type", isAttribute = true) String type,
                     @JacksonXmlProperty(localName = "ID") String id,
                     @JacksonXmlProperty(localName = "DisplayName")
                     String displayName,

--- a/src/main/java/org/gaul/s3proxy/CompleteMultipartUploadRequest.java
+++ b/src/main/java/org/gaul/s3proxy/CompleteMultipartUploadRequest.java
@@ -18,8 +18,8 @@ package org.gaul.s3proxy;
 
 import java.util.Collection;
 
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 record CompleteMultipartUploadRequest(
         @JacksonXmlProperty(localName = "Part")

--- a/src/main/java/org/gaul/s3proxy/CreateBucketRequest.java
+++ b/src/main/java/org/gaul/s3proxy/CreateBucketRequest.java
@@ -16,7 +16,7 @@
 
 package org.gaul.s3proxy;
 
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 record CreateBucketRequest(
         @JacksonXmlProperty(localName = "LocationConstraint")

--- a/src/main/java/org/gaul/s3proxy/DeleteMultipleObjectsRequest.java
+++ b/src/main/java/org/gaul/s3proxy/DeleteMultipleObjectsRequest.java
@@ -18,8 +18,8 @@ package org.gaul.s3proxy;
 
 import java.util.Collection;
 
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 record DeleteMultipleObjectsRequest(
         @JacksonXmlProperty(localName = "Quiet") boolean quiet,

--- a/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
@@ -61,10 +61,6 @@ import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.xml.XmlFactory;
-import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.google.common.base.CharMatcher;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
@@ -119,6 +115,13 @@ import org.jclouds.s3.domain.ObjectMetadata.StorageClass;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import tools.jackson.core.exc.StreamReadException;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.dataformat.xml.XmlFactory;
+import tools.jackson.dataformat.xml.XmlMapper;
+import tools.jackson.dataformat.xml.XmlReadFeature;
 
 /** HTTP server-independent handler for S3 requests. */
 public class S3ProxyHandler {
@@ -321,7 +324,12 @@ public class S3ProxyHandler {
         inputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
         inputFactory.setProperty(
                 XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
-        return new XmlMapper(new XmlFactory(inputFactory));
+        return XmlMapper.builder(new XmlFactory(inputFactory))
+                .configure(
+                        DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES,
+                        false)
+                .disable(XmlReadFeature.AUTO_DETECT_XSI_TYPE)
+                .build();
     }
 
     private static String getBlobStoreType(BlobStore blobStore) {
@@ -1497,7 +1505,7 @@ public class S3ProxyHandler {
                 CreateBucketRequest cbr;
                 try {
                     cbr = mapper.readValue(pis, CreateBucketRequest.class);
-                } catch (JsonParseException jpe) {
+                } catch (StreamReadException jpe) {
                     throw new S3Exception(S3ErrorCode.MALFORMED_X_M_L, jpe);
                 }
                 locationString = cbr.locationConstraint();
@@ -2762,7 +2770,7 @@ public class S3ProxyHandler {
             try {
                 cmu = mapper.readValue(
                         is, CompleteMultipartUploadRequest.class);
-            } catch (JsonParseException jpe) {
+            } catch (StreamReadException jpe) {
                 throw new S3Exception(S3ErrorCode.MALFORMED_X_M_L, jpe);
             }
 
@@ -2816,7 +2824,7 @@ public class S3ProxyHandler {
             try {
                 cmu = mapper.readValue(
                         is, CompleteMultipartUploadRequest.class);
-            } catch (JsonParseException jpe) {
+            } catch (StreamReadException jpe) {
                 throw new S3Exception(S3ErrorCode.MALFORMED_X_M_L, jpe);
             }
 


### PR DESCRIPTION
Jackson 3.x relocated the Maven groupId from com.fasterxml.jackson to tools.jackson and mirrored the package namespace. Adjust imports and adapt to two behavior changes that broke s3proxy:

- JsonParseException was removed; the streaming-level replacement is tools.jackson.core.exc.StreamReadException.
- FAIL_ON_NULL_FOR_PRIMITIVES now defaults to true, which rejected DeleteMultipleObjectsRequest XML that omits <Quiet>. Restore the legacy default on the XmlMapper.
- AUTO_DETECT_XSI_TYPE now defaults to true and swallows xsi:type as polymorphic-type metadata, leaving Grantee.type null. Disable it so the attribute is mapped as a regular field, and update the matching @JacksonXmlProperty namespace to the real XSI URI.

Closes #1065.