### PR TITLE
Bump software.amazon.awssdk:bom from 2.44.7 to 2.46.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -437,7 +437,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>17</java.version>
-    <aws-sdkv2.version>2.44.7</aws-sdkv2.version>
+    <aws-sdkv2.version>2.46.0</aws-sdkv2.version>
     <jclouds.version>2.7.0</jclouds.version>
     <jetty.version>12.1.9</jetty.version>
     <modernizer.version>3.4.0</modernizer.version>
@@ -642,6 +642,11 @@
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sts</artifactId>
       <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>apache5-client</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/src/test/java/org/gaul/s3proxy/AwsSdkAnonymousTest.java
+++ b/src/test/java/org/gaul/s3proxy/AwsSdkAnonymousTest.java
@@ -36,7 +36,7 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.http.SdkHttpConfigurationOption;
-import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.http.apache5.Apache5HttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3Configuration;
@@ -150,7 +150,7 @@ public final class AwsSdkAnonymousTest {
                 .credentialsProvider(credentialsProvider)
                 .region(Region.US_EAST_1)
                 .endpointOverride(s3EndpointUri)
-                .httpClient(ApacheHttpClient.builder()
+                .httpClient(Apache5HttpClient.builder()
                         .buildWithDefaults(attributeMap))
                 .serviceConfiguration(S3Configuration.builder()
                         .pathStyleAccessEnabled(true)

--- a/src/test/java/org/gaul/s3proxy/AwsSdkTest.java
+++ b/src/test/java/org/gaul/s3proxy/AwsSdkTest.java
@@ -65,7 +65,7 @@ import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.http.SdkHttpConfigurationOption;
-import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.http.apache5.Apache5HttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3Configuration;
@@ -167,7 +167,7 @@ public final class AwsSdkTest {
                 .credentialsProvider(creds)
                 .region(Region.US_EAST_1)
                 .endpointOverride(s3EndpointUri)
-                .httpClient(ApacheHttpClient.builder()
+                .httpClient(Apache5HttpClient.builder()
                         .buildWithDefaults(attributeMap))
                 .serviceConfiguration(S3Configuration.builder()
                         .pathStyleAccessEnabled(true)
@@ -232,7 +232,7 @@ public final class AwsSdkTest {
                 .credentialsProvider(StaticCredentialsProvider.create(awsCreds))
                 .region(Region.US_EAST_1)
                 .endpointOverride(s3EndpointUri)
-                .httpClient(ApacheHttpClient.builder()
+                .httpClient(Apache5HttpClient.builder()
                         .buildWithDefaults(attributeMap))
                 .serviceConfiguration(S3Configuration.builder()
                         .pathStyleAccessEnabled(true)

--- a/src/test/java/org/gaul/s3proxy/CrossOriginResourceSharingAllowAllResponseTest.java
+++ b/src/test/java/org/gaul/s3proxy/CrossOriginResourceSharingAllowAllResponseTest.java
@@ -55,7 +55,7 @@ import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.http.SdkHttpConfigurationOption;
-import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.http.apache5.Apache5HttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3Configuration;
@@ -102,7 +102,7 @@ public final class CrossOriginResourceSharingAllowAllResponseTest {
                 .credentialsProvider(credsProvider)
                 .region(Region.US_EAST_1)
                 .endpointOverride(s3EndpointUri)
-                .httpClient(ApacheHttpClient.builder()
+                .httpClient(Apache5HttpClient.builder()
                         .buildWithDefaults(attributeMap))
                 .serviceConfiguration(serviceConfig)
                 .build();

--- a/src/test/java/org/gaul/s3proxy/CrossOriginResourceSharingResponseTest.java
+++ b/src/test/java/org/gaul/s3proxy/CrossOriginResourceSharingResponseTest.java
@@ -55,7 +55,7 @@ import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.http.SdkHttpConfigurationOption;
-import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.http.apache5.Apache5HttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3Configuration;
@@ -103,7 +103,7 @@ public final class CrossOriginResourceSharingResponseTest {
                 .credentialsProvider(credsProvider)
                 .region(Region.US_EAST_1)
                 .endpointOverride(s3EndpointUri)
-                .httpClient(ApacheHttpClient.builder()
+                .httpClient(Apache5HttpClient.builder()
                         .buildWithDefaults(attributeMap))
                 .serviceConfiguration(serviceConfig)
                 .build();

--- a/src/test/java/org/gaul/s3proxy/junit/S3ProxyExtensionTest.java
+++ b/src/test/java/org/gaul/s3proxy/junit/S3ProxyExtensionTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.sync.RequestBody;
-import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.http.apache5.Apache5HttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3Configuration;
@@ -63,7 +63,7 @@ public class S3ProxyExtensionTest {
                     EXTENSION.getAccessKey(), EXTENSION.getSecretKey())))
             .region(Region.US_EAST_1)
             .endpointOverride(EXTENSION.getUri())
-            .httpClient(ApacheHttpClient.builder().build())
+            .httpClient(Apache5HttpClient.builder().build())
             .serviceConfiguration(S3Configuration.builder()
                 .pathStyleAccessEnabled(true)
                 .build())

--- a/src/test/java/org/gaul/s3proxy/junit/S3ProxyRuleTest.java
+++ b/src/test/java/org/gaul/s3proxy/junit/S3ProxyRuleTest.java
@@ -29,7 +29,7 @@ import org.junit.rules.TemporaryFolder;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.sync.RequestBody;
-import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.http.apache5.Apache5HttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3Configuration;
@@ -61,7 +61,7 @@ public class S3ProxyRuleTest {
                     s3Proxy.getAccessKey(), s3Proxy.getSecretKey())))
             .region(Region.US_EAST_1)
             .endpointOverride(s3Proxy.getUri())
-            .httpClient(ApacheHttpClient.builder().build())
+            .httpClient(Apache5HttpClient.builder().build())
             .serviceConfiguration(S3Configuration.builder()
                 .pathStyleAccessEnabled(true)
                 .build())


### PR DESCRIPTION
The SDK's services parent pom replaced its runtime transitive on apache-client (Apache HttpClient 4.x) with apache5-client (5.x), so software.amazon.awssdk.http.apache.ApacheHttpClient is no longer on the test classpath by default. Migrate the test code to the 5.x counterpart and declare apache5-client explicitly as a test-scope dependency.

Closes #1062.