### PR TITLE
Fix AwsS3SdkBlobStore.containerExists to translate non-404 S3Exception

### DIFF
--- a/src/main/java/org/gaul/s3proxy/awssdk/AwsS3SdkBlobStore.java
+++ b/src/main/java/org/gaul/s3proxy/awssdk/AwsS3SdkBlobStore.java
@@ -288,7 +288,7 @@ public final class AwsS3SdkBlobStore extends BaseBlobStore {
             if (e.statusCode() == 404) {
                 return false;
             }
-            throw e;
+            throw translate(e, container, null);
         }
     }
 


### PR DESCRIPTION
When containerExists receives an S3Exception with a status code other than 404, it re-throws it raw. S3ProxyHandler only handles jclouds exceptions, so the raw S3Exception propagates to Jetty and results in a 500 Internal Server Error.
Change:

```diff
+ throw translate(e, container, null);
  throw e;
```

### Why this matters
Some S3-compatible backends return 403 Forbidden instead of 404 Not Found for HEAD requests on non-existent containers. OpenStack Swift is one example — it returns 403 for a non-existent container when the requesting credentials don't have explicit list permissions. This causes every containerExists probe (e.g. during mc alias set) to produce a 500 instead of the correct 404/false response.
The jclouds s3 backend does not have this issue because all exceptions go through its own translation chain before reaching S3ProxyHandler

Fixes https://github.com/gaul/s3proxy/issues/1073
