### PR TITLE
Report Size/LastModified/ETag in the ListObjects call for `directory-marker` objects stored nio2-based backends. Fixes #1093

### DIFF
--- a/src/main/java/org/gaul/s3proxy/nio2blob/AbstractNio2BlobStore.java
+++ b/src/main/java/org/gaul/s3proxy/nio2blob/AbstractNio2BlobStore.java
@@ -239,17 +239,40 @@ public abstract class AbstractNio2BlobStore extends BaseBlobStore {
                                 filterMultipart);
                     }
 
+                    var dirXattrs = safeGetXattrs(path);
+                    var markerExists = dirXattrs.attributes()
+                            .contains(XATTR_CONTENT_MD5);
+
                     // Add a prefix if the directory blob exists or if the delimiter causes us not to recuse.
-                    if ("/".equals(delimiter) || safeGetXattrs(path).attributes().contains(XATTR_CONTENT_MD5)) {
+                    if ("/".equals(delimiter) || markerExists) {
                         var name = relativeName(containerPath, path);
                         logger.debug("adding prefix: {}", name);
+
+                        // A directory-marker object (a key ending in "/") that
+                        // was explicitly stored carries the XATTR_CONTENT_MD5
+                        // xattr. Report its metadata so a non-delimited
+                        // ListObjects, which emits this entry as <Contents>,
+                        // includes Size/LastModified/ETag like any other
+                        // 0-byte object. Implicit prefixes (no marker object)
+                        // keep null metadata since they surface only as
+                        // <CommonPrefixes>.
+                        String eTag = null;
+                        Date lastModified = null;
+                        Long size = null;
+                        if (markerExists) {
+                            eTag = readETagXattr(dirXattrs);
+                            lastModified = new Date(
+                                    attr.lastModifiedTime().toMillis());
+                            size = 0L;
+                        }
+
                         builder.add(new StorageMetadataImpl(
                                 StorageType.RELATIVE_PATH,
                                 /*id=*/ null, name + "/",
                                 /*location=*/ null, /*uri=*/ null,
-                                /*eTag=*/ null, /*creationDate=*/ null,
-                                /*lastModified=*/ null,
-                                Map.of(), /*size=*/ null, Tier.STANDARD));
+                                eTag, /*creationDate=*/ null,
+                                lastModified,
+                                Map.of(), size, Tier.STANDARD));
                     }
                 } else {
                     var name = relativeName(containerPath, path);
@@ -257,27 +280,13 @@ public abstract class AbstractNio2BlobStore extends BaseBlobStore {
                     var lastModifiedTime = new Date(attr.lastModifiedTime().toMillis());
                     var creationTime = new Date(attr.creationTime().toMillis());
 
-                    String eTag = null;
-                    Tier tier = Tier.STANDARD;
                     var xattrs = safeGetXattrs(path);
+                    String eTag = readETagXattr(xattrs);
+                    Tier tier = Tier.STANDARD;
                     if (xattrs.view() != null) {
-                        var view = xattrs.view();
-                        var attributes = xattrs.attributes();
-                        if (attributes.contains(XATTR_CONTENT_MD5)) {
-                            var buf = ByteBuffer.allocate(view.size(XATTR_CONTENT_MD5));
-                            view.read(XATTR_CONTENT_MD5, buf);
-                            var etagBytes = buf.array();
-                            if (etagBytes.length == 16) {
-                                // regular object
-                                var hashCode = HashCode.fromBytes(buf.array());
-                                eTag = "\"" + hashCode + "\"";
-                            } else {
-                                // multi-part object
-                                eTag = new String(etagBytes, StandardCharsets.US_ASCII);
-                            }
-                        }
-
-                        var tierString = readStringAttributeIfPresent(view, attributes, XATTR_STORAGE_TIER);
+                        var tierString = readStringAttributeIfPresent(
+                                xattrs.view(), xattrs.attributes(),
+                                XATTR_STORAGE_TIER);
                         if (tierString != null) {
                             tier = Tier.valueOf(tierString);
                         }
@@ -1069,6 +1078,28 @@ public abstract class AbstractNio2BlobStore extends BaseBlobStore {
         ByteBuffer buf = ByteBuffer.allocate(view.size(name));
         view.read(name, buf);
         return new String(buf.array(), StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Reads the stored ETag for an object from its XATTR_CONTENT_MD5 xattr, or
+     * null when the object carries no such xattr (e.g. an implicit directory).
+     * A 16-byte value is the MD5 of a single-part object; anything else is a
+     * multipart ETag stored verbatim.
+     */
+    private static String readETagXattr(XattrState xattrs) throws IOException {
+        var view = xattrs.view();
+        if (view == null || !xattrs.attributes().contains(XATTR_CONTENT_MD5)) {
+            return null;
+        }
+        var buf = ByteBuffer.allocate(view.size(XATTR_CONTENT_MD5));
+        view.read(XATTR_CONTENT_MD5, buf);
+        var etagBytes = buf.array();
+        if (etagBytes.length == 16) {
+            // regular object
+            return "\"" + HashCode.fromBytes(etagBytes) + "\"";
+        }
+        // multi-part object
+        return new String(etagBytes, StandardCharsets.US_ASCII);
     }
 
     /** Write the String representation of a filesystem attribute. */

--- a/src/main/java/org/gaul/s3proxy/nio2blob/AbstractNio2BlobStore.java
+++ b/src/main/java/org/gaul/s3proxy/nio2blob/AbstractNio2BlobStore.java
@@ -184,6 +184,28 @@ public abstract class AbstractNio2BlobStore extends BaseBlobStore {
         try {
             listHelper(set, containerPath, dirPrefix, pathPrefixString, delimiter,
                     filterMultipart);
+
+            // A directory-marker object whose key equals the requested prefix
+            // (e.g. prefix "dir-marker/") is the prefix directory itself, into
+            // which listHelper descends and lists children -- so it never
+            // emits the marker. Real S3 returns keys >= prefix that start with
+            // the prefix, including this exact key, so add it here. It is a
+            // BLOB (not a prefix) because its remainder after the prefix is
+            // empty, placing it in <Contents> regardless of the delimiter.
+            if (prefix.endsWith("/") && Files.isDirectory(pathPrefix)) {
+                var markerXattrs = safeGetXattrs(pathPrefix);
+                if (markerXattrs.attributes().contains(XATTR_CONTENT_MD5)) {
+                    var attr = Files.readAttributes(pathPrefix,
+                            BasicFileAttributes.class);
+                    set.add(new StorageMetadataImpl(StorageType.BLOB,
+                            /*id=*/ null, prefix,
+                            /*location=*/ null, /*uri=*/ null,
+                            readETagXattr(markerXattrs), /*creationDate=*/ null,
+                            new Date(attr.lastModifiedTime().toMillis()),
+                            Map.of(), /*size=*/ 0L, Tier.STANDARD));
+                }
+            }
+
             var sorted = set.build();
             if (options.getMarker() != null) {
                 // StorageMetadata's natural ordering is name-only (nulls

--- a/src/test/java/org/gaul/s3proxy/AwsSdkTest.java
+++ b/src/test/java/org/gaul/s3proxy/AwsSdkTest.java
@@ -87,6 +87,7 @@ import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 import software.amazon.awssdk.services.s3.model.Permission;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.model.S3Object;
 import software.amazon.awssdk.services.s3.model.StorageClass;
 import software.amazon.awssdk.services.s3.model.Tagging;
 import software.amazon.awssdk.services.s3.model.Type;
@@ -983,6 +984,48 @@ public final class AwsSdkTest {
         client.deleteObject(b -> b.bucket(containerName).key(dirName));
         assertThat(client.headObject(
                 b -> b.bucket(containerName).key(marker))).isNotNull();
+    }
+
+    @Test
+    public void testDirectoryMarkerListMetadata() throws Exception {
+        // Per the S3 API every <Contents> entry in a ListObjects(V1/V2)
+        // response must carry <Size>, <LastModified> and <ETag>, even for a
+        // "directory placeholder" key (one ending in "/"). The nio2 backends
+        // used to omit them for such keys, so spec-abiding clients (e.g.
+        // Hadoop's S3A connector) read a null/absent size and NPE.
+        assumeTrue(blobStoreType.equals("filesystem-nio2") ||
+                blobStoreType.equals("transient-nio2"));
+
+        String marker = "dir-marker/";
+        client.putObject(b -> b.bucket(containerName).key(marker),
+                RequestBody.empty());
+
+        // sanity: the server knows the marker's size via HEAD
+        assertThat(client.headObject(
+                b -> b.bucket(containerName).key(marker)).contentLength())
+                .isEqualTo(0L);
+
+        // ListObjectsV2 must report Size/LastModified/ETag for the marker.
+        ListObjectsV2Response v2 = client.listObjectsV2(
+                b -> b.bucket(containerName));
+        S3Object v2Marker = v2.contents().stream()
+                .filter(o -> o.key().equals(marker))
+                .findFirst().orElse(null);
+        assertThat(v2Marker).isNotNull();
+        assertThat(v2Marker.size()).isEqualTo(0L);
+        assertThat(v2Marker.lastModified()).isNotNull();
+        assertThat(v2Marker.eTag()).isNotBlank();
+
+        // ListObjects (v1) must do the same.
+        ListObjectsResponse v1 = client.listObjects(
+                b -> b.bucket(containerName));
+        S3Object v1Marker = v1.contents().stream()
+                .filter(o -> o.key().equals(marker))
+                .findFirst().orElse(null);
+        assertThat(v1Marker).isNotNull();
+        assertThat(v1Marker.size()).isEqualTo(0L);
+        assertThat(v1Marker.lastModified()).isNotNull();
+        assertThat(v1Marker.eTag()).isNotBlank();
     }
 
     @Test

--- a/src/test/java/org/gaul/s3proxy/AwsSdkTest.java
+++ b/src/test/java/org/gaul/s3proxy/AwsSdkTest.java
@@ -1029,6 +1029,41 @@ public final class AwsSdkTest {
     }
 
     @Test
+    public void testDirectoryMarkerListSelfPrefix() throws Exception {
+        // Listing with a prefix equal to a directory-marker key
+        // ("dir-marker/") must return that marker object itself, exactly as
+        // real S3 returns keys >= prefix that start with the prefix. Hadoop
+        // S3A's empty-directory probe (list prefix="<dir>/" delimiter="/")
+        // relies on this; otherwise getFileStatus(<dir>) throws
+        // FileNotFoundException, breaking HBase bulk load.
+        assumeTrue(blobStoreType.equals("filesystem-nio2") ||
+                blobStoreType.equals("transient-nio2"));
+
+        String marker = "dir-marker/";
+        client.putObject(b -> b.bucket(containerName).key(marker),
+                RequestBody.empty());
+
+        // The key equals the prefix, so its remainder after the prefix is
+        // empty and it belongs in <Contents>, not <CommonPrefixes>.
+        ListObjectsV2Response v2 = client.listObjectsV2(b -> b
+                .bucket(containerName).prefix(marker).delimiter("/"));
+        S3Object v2Self = v2.contents().stream()
+                .filter(o -> o.key().equals(marker))
+                .findFirst().orElse(null);
+        assertThat(v2Self).isNotNull();
+        assertThat(v2Self.size()).isEqualTo(0L);
+
+        // ListObjects (v1) with the same prefix must do the same.
+        ListObjectsResponse v1 = client.listObjects(b -> b
+                .bucket(containerName).prefix(marker).delimiter("/"));
+        S3Object v1Self = v1.contents().stream()
+                .filter(o -> o.key().equals(marker))
+                .findFirst().orElse(null);
+        assertThat(v1Self).isNotNull();
+        assertThat(v1Self.size()).isEqualTo(0L);
+    }
+
+    @Test
     public void testSinglepartUploadJettyCachedHeader() throws Exception {
         String blobName = "singlepart-upload-jetty-cached";
         String contentType = "text/plain";


### PR DESCRIPTION
This PR fixes and issue where `directory-marker` objects, which are empty objects with a trailing "/" do not get their object information reported for the ListObjects() call. This is a problem in hadoop-aws, which release on those kinds of objects.

More details:

AbstractNio2BlobStore.listHelper() added directory-marker objects (keys ending in "/", stored as a directory carrying the XATTR_CONTENT_MD5 xattr) to listings with hardcoded null eTag, lastModified and size. For a non-delimited ListObjects(V1/V2) the handler emits such an entry as `<Contents>` but then omits `<Size>`, `<LastModified>` and `<ETag>` because each is null, so spec-abiding clients (e.g. Hadoop's S3A connector) read a null size and NPE.

Populate the metadata from the directory's attributes when the marker object exists (eTag from XATTR_CONTENT_MD5, size 0, lastModified from the file), mirroring the getBlob/HEAD path. Implicit prefixes that have no marker object keep null metadata since they surface only as `<CommonPrefixes>`. Factor the duplicated ETag-from-xattr logic into a readETagXattr() helper.

This fixes https://github.com/gaul/s3proxy/issues/1093