### PR TITLE
Refresh runtime OS packages in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ LABEL maintainer="Andrew Gaul <andrew@gaul.org>"
 WORKDIR /opt/s3proxy
 
 RUN apt-get update && \
+    apt-get upgrade -y && \
     apt-get install -y dumb-init && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary

Upgrade the runtime image’s installed Ubuntu packages before adding `dumb-init`. This prevents Docker builds from retaining packages that have security updates available after the base image was published.

A current build upgraded nine packages, including `curl`, `libcurl4t64`, `libgcrypt20`, `libnghttp2-14`, `libssh2-1t64`, `tar`, and `wget`.

## Validation

- `mvn package -DskipTests`
- `docker build --pull -t s3proxy-runtime-refresh-test .`
- Verified `apt-get -s upgrade` reports zero remaining upgrades in the resulting image
- Verified `dumb-init --version` and `/opt/s3proxy/s3proxy --version` execute successfully