### PR TITLE
Acknowledge SSE-S3 (accept + echo), partially resolving #402

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,13 @@ S3Proxy has broad compatibility with the S3 API, however, it does not support:
 * hosting static websites
 * object lock, including legal hold and retention
 * object ownership controls
-* object server-side encryption, see [#402](https://github.com/gaul/s3proxy/issues/402)
+* object server-side encryption, see [#402](https://github.com/gaul/s3proxy/issues/402);
+  SSE-S3 (AES256) is accepted and echoed on PUT/HEAD/GET/copy/complete only when
+  objects are truly encrypted at rest -- a backend that always encrypts
+  (S3/Azure/GCS) or when `s3proxy.encrypted-blobstore` is enabled -- and rejected
+  otherwise, so the proxy never claims encryption it is not performing. Override
+  this default with `s3proxy.server-side-encryption` (`reject` | `ignore` |
+  `sse-s3`). SSE-KMS and SSE-C remain unsupported
 * object tagging
 * object versioning on backends other than aws-s3-sdk, see [#74](https://github.com/gaul/s3proxy/issues/74)
 * paginating ListParts with `part-number-marker`

--- a/src/main/java/org/gaul/s3proxy/AwsHttpHeaders.java
+++ b/src/main/java/org/gaul/s3proxy/AwsHttpHeaders.java
@@ -49,6 +49,14 @@ final class AwsHttpHeaders {
     static final String OBJECT_ATTRIBUTES = "x-amz-object-attributes";
     static final String REQUEST_ID = "x-amz-request-id";
     static final String SDK_CHECKSUM_ALGORITHM = "x-amz-sdk-checksum-algorithm";
+    static final String SERVER_SIDE_ENCRYPTION =
+            "x-amz-server-side-encryption";
+    static final String SSE_CUSTOMER_ALGORITHM =
+            "x-amz-server-side-encryption-customer-algorithm";
+    static final String SSE_CUSTOMER_KEY =
+            "x-amz-server-side-encryption-customer-key";
+    static final String SSE_CUSTOMER_KEY_MD5 =
+            "x-amz-server-side-encryption-customer-key-md5";
     static final String STORAGE_CLASS = "x-amz-storage-class";
     static final String TRAILER = "x-amz-trailer";
     static final String TRANSFER_ENCODING = "x-amz-te";

--- a/src/main/java/org/gaul/s3proxy/Quirks.java
+++ b/src/main/java/org/gaul/s3proxy/Quirks.java
@@ -25,6 +25,20 @@ final class Quirks {
             "openstack-swift"
     );
 
+    /**
+     * Blobstores that always encrypt objects at rest, so acknowledging an
+     * SSE-S3 (AES256) request with a matching echo is truthful. The
+     * s3proxy.server-side-encryption default is derived from this set:
+     * "sse-s3" for these, "reject" otherwise.
+     */
+    static final Set<String> SERVER_SIDE_ENCRYPTION_AT_REST = Set.of(
+            "azureblob",
+            "azureblob-sdk",
+            "aws-s3",
+            "aws-s3-sdk",
+            "s3"
+    );
+
     /** Blobstores which do not support the Cache-Control header. */
     static final Set<String> NO_CACHE_CONTROL_SUPPORT = Set.of(
             "google-cloud-storage",

--- a/src/main/java/org/gaul/s3proxy/S3Proxy.java
+++ b/src/main/java/org/gaul/s3proxy/S3Proxy.java
@@ -152,7 +152,8 @@ public final class S3Proxy {
                 builder.maxSinglePartObjectSize,
                 builder.v4MaxNonChunkedRequestSize,
                 builder.v4MaxChunkSize,
-                builder.ignoreUnknownHeaders, builder.corsRules,
+                builder.ignoreUnknownHeaders, builder.serverSideEncryption,
+                builder.corsRules,
                 builder.servicePath, builder.maximumTimeSkew, metrics);
 
         var context = new ServletContextHandler();
@@ -218,6 +219,8 @@ public final class S3Proxy {
         private long v4MaxNonChunkedRequestSize = 128 * 1024 * 1024;
         private int v4MaxChunkSize = 16 * 1024 * 1024;
         private boolean ignoreUnknownHeaders;
+        private S3ProxyHandler.SseMode serverSideEncryption =
+                S3ProxyHandler.SseMode.REJECT;
         @Nullable private CrossOriginResourceSharing corsRules;
         private int jettyMaxThreads = 200;  // sourced from QueuedThreadPool()
         private int maximumTimeSkew = 15 * 60;
@@ -341,6 +344,30 @@ public final class S3Proxy {
             if (!Strings.isNullOrEmpty(ignoreUnknownHeaders)) {
                 builder.ignoreUnknownHeaders(Boolean.parseBoolean(
                         ignoreUnknownHeaders));
+            }
+
+            String serverSideEncryption = properties.getProperty(
+                    S3ProxyConstants.PROPERTY_SERVER_SIDE_ENCRYPTION);
+            if (!Strings.isNullOrEmpty(serverSideEncryption)) {
+                // Explicit operator override always wins.
+                builder.serverSideEncryption(
+                        S3ProxyHandler.SseMode.parse(serverSideEncryption));
+            } else {
+                // Default reflects what the backend can TRUTHFULLY claim:
+                // acknowledge SSE-S3 only where objects really are encrypted at
+                // rest -- either a backend that always encrypts (S3/Azure/GCS)
+                // or when the proxy itself encrypts via EncryptedBlobStore --
+                // and reject otherwise rather than assert encryption that is
+                // not happening. Operators can override with the property above.
+                String provider = properties.getProperty("jclouds.provider");
+                boolean encryptedBlobStore = "true".equalsIgnoreCase(
+                        properties.getProperty(
+                            S3ProxyConstants.PROPERTY_ENCRYPTED_BLOBSTORE));
+                boolean atRest = provider != null && Quirks
+                        .SERVER_SIDE_ENCRYPTION_AT_REST.contains(provider);
+                builder.serverSideEncryption(encryptedBlobStore || atRest ?
+                        S3ProxyHandler.SseMode.SSE_S3 :
+                        S3ProxyHandler.SseMode.REJECT);
             }
 
             String corsAllowAll = properties.getProperty(
@@ -493,6 +520,12 @@ public final class S3Proxy {
 
         public Builder ignoreUnknownHeaders(boolean ignoreUnknownHeaders) {
             this.ignoreUnknownHeaders = ignoreUnknownHeaders;
+            return this;
+        }
+
+        public Builder serverSideEncryption(
+                S3ProxyHandler.SseMode serverSideEncryption) {
+            this.serverSideEncryption = serverSideEncryption;
             return this;
         }
 

--- a/src/main/java/org/gaul/s3proxy/S3ProxyConstants.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyConstants.java
@@ -48,6 +48,16 @@ public final class S3ProxyConstants {
             "s3proxy.credential";
     public static final String PROPERTY_IGNORE_UNKNOWN_HEADERS =
             "s3proxy.ignore-unknown-headers";
+    // How to handle the x-amz-server-side-encryption request header. When unset
+    // the default reflects what the backend can truthfully claim: sse-s3 on
+    // stores that encrypt at rest (or with encrypted-blobstore enabled), else
+    // reject. This property overrides that default:
+    //   reject  -- 501 NotImplemented
+    //   ignore  -- accept the PUT, drop the header, do not echo
+    //   sse-s3  -- accept AES256, echo it on PUT/HEAD/GET/copy/complete
+    // aws:kms and SSE-C are always rejected regardless of this setting.
+    public static final String PROPERTY_SERVER_SIDE_ENCRYPTION =
+            "s3proxy.server-side-encryption";
     public static final String PROPERTY_KEYSTORE_PATH =
             "s3proxy.keystore-path";
     public static final String PROPERTY_KEYSTORE_PASSWORD =

--- a/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
@@ -281,6 +281,10 @@ public class S3ProxyHandler {
             AwsHttpHeaders.METADATA_DIRECTIVE,
             AwsHttpHeaders.OBJECT_ATTRIBUTES,
             AwsHttpHeaders.SDK_CHECKSUM_ALGORITHM,  // TODO: ignoring header
+            AwsHttpHeaders.SERVER_SIDE_ENCRYPTION,
+            AwsHttpHeaders.SSE_CUSTOMER_ALGORITHM,
+            AwsHttpHeaders.SSE_CUSTOMER_KEY,
+            AwsHttpHeaders.SSE_CUSTOMER_KEY_MD5,
             AwsHttpHeaders.STORAGE_CLASS,
             AwsHttpHeaders.TRAILER,
             AwsHttpHeaders.TRANSFER_ENCODING,  // TODO: ignoring header
@@ -338,6 +342,7 @@ public class S3ProxyHandler {
     private final long v4MaxNonChunkedRequestSize;
     private final int v4MaxChunkSize;
     private final boolean ignoreUnknownHeaders;
+    private final SseMode serverSideEncryption;
     private final CrossOriginResourceSharing corsRules;
     private final String servicePath;
     private final int maximumTimeSkew;
@@ -359,6 +364,35 @@ public class S3ProxyHandler {
             .expireAfterWrite(Duration.ofMinutes(10))
             .build();
 
+    /** Policy for the x-amz-server-side-encryption request header. */
+    enum SseMode {
+        /** 501 NotImplemented for any SSE header (default; prior behavior). */
+        REJECT,
+        /** Accept the PUT, drop the header, do not echo it back. */
+        IGNORE,
+        /** Accept AES256 and echo it (backend encrypts at rest). */
+        SSE_S3;
+
+        static SseMode parse(String value) {
+            if (value == null) {
+                return REJECT;
+            }
+            switch (value.trim().toLowerCase(java.util.Locale.ROOT)) {
+            case "ignore":
+                return IGNORE;
+            case "sse-s3":
+            case "aes256":
+                return SSE_S3;
+            case "reject":
+            case "":
+                return REJECT;
+            default:
+                throw new IllegalArgumentException(
+                        "invalid s3proxy.server-side-encryption: " + value);
+            }
+        }
+    }
+
     public S3ProxyHandler(final BlobStore blobStore,
             AuthenticationType authenticationType,
             @Nullable final String identity,
@@ -366,6 +400,7 @@ public class S3ProxyHandler {
             long maxSinglePartObjectSize, long v4MaxNonChunkedRequestSize,
             int v4MaxChunkSize,
             boolean ignoreUnknownHeaders,
+            SseMode serverSideEncryption,
             @Nullable CrossOriginResourceSharing corsRules,
             @Nullable final String servicePath, int maximumTimeSkew) {
         if (corsRules != null) {
@@ -411,6 +446,7 @@ public class S3ProxyHandler {
         this.v4MaxNonChunkedRequestSize = v4MaxNonChunkedRequestSize;
         this.v4MaxChunkSize = v4MaxChunkSize;
         this.ignoreUnknownHeaders = ignoreUnknownHeaders;
+        this.serverSideEncryption = serverSideEncryption;
         this.defaultBlobStore = blobStore;
         xmlOutputFactory.setProperty("javax.xml.stream.isRepairingNamespaces", false);
         this.servicePath = Strings.nullToEmpty(servicePath);
@@ -2867,6 +2903,7 @@ public class S3ProxyHandler {
         response.setStatus(HttpServletResponse.SC_OK);
         addMetadataToResponse(request, response, metadata,
                 /*partialContent=*/ false);
+        echoServerSideEncryptionIfConfigured(response);
         addCorsResponseHeader(request, response);
     }
 
@@ -3287,6 +3324,7 @@ public class S3ProxyHandler {
         addMetadataToResponse(request, response,
                 SdkResponses.toHead(blob.response()),
                 status == HttpServletResponse.SC_PARTIAL_CONTENT);
+        echoServerSideEncryptionIfConfigured(response);
 
         // TODO: handles only a single range due to blobstore API limitations
         String contentRange = blob.response().contentRange();
@@ -3489,6 +3527,7 @@ public class S3ProxyHandler {
         if (destVersionId != null) {
             response.addHeader(AwsHttpHeaders.VERSION_ID, destVersionId);
         }
+        echoServerSideEncryptionIfConfigured(response);
         try (Writer writer = response.getWriter()) {
             response.setContentType(XML_CONTENT_TYPE);
             XMLStreamWriter xml = xmlOutputFactory.createXMLStreamWriter(
@@ -3517,10 +3556,57 @@ public class S3ProxyHandler {
         }
     }
 
+    /**
+     * Apply the configured s3proxy.server-side-encryption policy to a PUT.
+     * SSE-S3 (AES256) is handled per policy; SSE-KMS (aws:kms) and SSE-C
+     * (customer-provided keys) are ALWAYS rejected -- silently ignoring a
+     * customer key would falsely imply the object was encrypted with it.
+     */
+    private void applyServerSideEncryptionPolicy(HttpServletRequest request,
+            HttpServletResponse response) {
+        if (request.getHeader(AwsHttpHeaders.SSE_CUSTOMER_ALGORITHM) != null ||
+                request.getHeader(AwsHttpHeaders.SSE_CUSTOMER_KEY) != null) {
+            throw new S3ProxyException(S3ErrorCode.NOT_IMPLEMENTED);
+        }
+        String sse = request.getHeader(AwsHttpHeaders.SERVER_SIDE_ENCRYPTION);
+        if (sse == null) {
+            return;
+        }
+        if (!sse.equalsIgnoreCase("AES256")) {
+            // aws:kms and any other mode need real key management.
+            throw new S3ProxyException(S3ErrorCode.NOT_IMPLEMENTED);
+        }
+        switch (serverSideEncryption) {
+        case IGNORE:
+            return;                       // accept, drop the header, no echo
+        case SSE_S3:
+            // Backend encrypts at rest; acknowledge on the PUT response. The
+            // matching echo on HEAD/GET is emitted by echoServerSideEncryptionIfConfigured.
+            response.addHeader(AwsHttpHeaders.SERVER_SIDE_ENCRYPTION, "AES256");
+            return;
+        case REJECT:
+        default:
+            throw new S3ProxyException(S3ErrorCode.NOT_IMPLEMENTED);
+        }
+    }
+
+    /**
+     * Echo x-amz-server-side-encryption: AES256 on read (HEAD/GET) when the
+     * proxy runs in sse-s3 mode. This mirrors real S3 with default bucket
+     * encryption -- which returns the header for every object -- and is
+     * truthful on the at-rest-encrypting backends sse-s3 is derived for.
+     */
+    private void echoServerSideEncryptionIfConfigured(HttpServletResponse response) {
+        if (serverSideEncryption == SseMode.SSE_S3) {
+            response.addHeader(AwsHttpHeaders.SERVER_SIDE_ENCRYPTION, "AES256");
+        }
+    }
+
     private void handlePutBlob(HttpServletRequest request,
             HttpServletResponse response, InputStream is, BlobStore blobStore,
             String containerName, String blobName)
             throws IOException {
+        applyServerSideEncryptionPolicy(request, response);
         // Flag headers present since HttpServletResponse.getHeader returns
         // null for empty headers values.
         String contentLengthString = null;
@@ -4557,6 +4643,7 @@ public class S3ProxyHandler {
             response.addHeader(AwsHttpHeaders.VERSION_ID,
                     completedResult.versionId());
         }
+        echoServerSideEncryptionIfConfigured(response);
         try (PrintWriter writer = response.getWriter()) {
             response.setStatus(HttpServletResponse.SC_OK);
             response.setContentType(XML_CONTENT_TYPE);

--- a/src/main/java/org/gaul/s3proxy/S3ProxyHandlerJetty.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyHandlerJetty.java
@@ -52,13 +52,14 @@ final class S3ProxyHandlerJetty extends HttpServlet {
             long maxSinglePartObjectSize, long v4MaxNonChunkedRequestSize,
             int v4MaxChunkSize,
             boolean ignoreUnknownHeaders,
+            S3ProxyHandler.SseMode serverSideEncryption,
             @Nullable CrossOriginResourceSharing corsRules,
             @Nullable String servicePath, int maximumTimeSkew,
             @Nullable S3ProxyMetrics metrics) {
         handler = new S3ProxyHandler(blobStore, authenticationType, identity,
                 credential, virtualHost, maxSinglePartObjectSize,
                 v4MaxNonChunkedRequestSize, v4MaxChunkSize,
-                ignoreUnknownHeaders, corsRules,
+                ignoreUnknownHeaders, serverSideEncryption, corsRules,
                 servicePath, maximumTimeSkew);
         this.metrics = metrics;
     }

--- a/src/test/java/org/gaul/s3proxy/ServerSideEncryptionTest.java
+++ b/src/test/java/org/gaul/s3proxy/ServerSideEncryptionTest.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2014-2026 Andrew Gaul <andrew@gaul.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gaul.s3proxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.net.URI;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.http.SdkHttpConfigurationOption;
+import software.amazon.awssdk.http.apache5.Apache5HttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.model.CompletedMultipartUpload;
+import software.amazon.awssdk.services.s3.model.CompletedPart;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.model.ServerSideEncryption;
+import software.amazon.awssdk.services.s3.model.UploadPartResponse;
+import software.amazon.awssdk.utils.AttributeMap;
+
+/**
+ * Exercises the s3proxy.server-side-encryption policy end to end over HTTP:
+ * how the proxy treats the x-amz-server-side-encryption request header under
+ * each mode, and the SseMode parser.
+ */
+public final class ServerSideEncryptionTest {
+    private static final String CONTAINER = "sse-test-container";
+    private static final String KEY = "sse-test-key";
+
+    private S3Proxy s3Proxy;
+    private S3Client client;
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        if (client != null) {
+            client.close();
+        }
+        if (s3Proxy != null) {
+            s3Proxy.stop();
+        }
+    }
+
+    /** Start a proxy from the given conf, build a client, create the bucket. */
+    private void launch(String configFile) throws Exception {
+        TestUtils.S3ProxyLaunchInfo info = TestUtils.startS3Proxy(configFile);
+        s3Proxy = info.getS3Proxy();
+        var creds = AwsBasicCredentials.create(
+                info.getS3Identity(), info.getS3Credential());
+        var endpoint = URI.create(
+                info.getSecureEndpoint().toString() + info.getServicePath());
+        var attributeMap = AttributeMap.builder()
+                .put(SdkHttpConfigurationOption.TRUST_ALL_CERTIFICATES, true)
+                .build();
+        client = S3Client.builder()
+                .credentialsProvider(StaticCredentialsProvider.create(creds))
+                .region(Region.US_EAST_1)
+                .endpointOverride(endpoint)
+                .httpClient(Apache5HttpClient.builder()
+                        .buildWithDefaults(attributeMap))
+                .serviceConfiguration(S3Configuration.builder()
+                        .pathStyleAccessEnabled(true)
+                        .build())
+                .build();
+        client.createBucket(b -> b.bucket(CONTAINER));
+    }
+
+    private PutObjectResponse putWithSse(ServerSideEncryption sse) {
+        return client.putObject(b -> b
+                        .bucket(CONTAINER).key(KEY).serverSideEncryption(sse),
+                RequestBody.fromString("hello sse"));
+    }
+
+    @Test
+    public void testSseS3AcceptedAndEchoedOnPutHeadGet() throws Exception {
+        launch("s3proxy-sse-s3.conf");
+
+        PutObjectResponse put = putWithSse(ServerSideEncryption.AES256);
+        assertThat(put.serverSideEncryption())
+                .isEqualTo(ServerSideEncryption.AES256);
+
+        HeadObjectResponse head = client.headObject(
+                b -> b.bucket(CONTAINER).key(KEY));
+        assertThat(head.serverSideEncryption())
+                .isEqualTo(ServerSideEncryption.AES256);
+
+        GetObjectResponse get = client.getObjectAsBytes(
+                b -> b.bucket(CONTAINER).key(KEY)).response();
+        assertThat(get.serverSideEncryption())
+                .isEqualTo(ServerSideEncryption.AES256);
+    }
+
+    @Test
+    public void testSseS3EchoedOnCopy() throws Exception {
+        launch("s3proxy-sse-s3.conf");
+        putWithSse(ServerSideEncryption.AES256);
+
+        var copy = client.copyObject(b -> b
+                .sourceBucket(CONTAINER).sourceKey(KEY)
+                .destinationBucket(CONTAINER).destinationKey(KEY + "-copy"));
+        assertThat(copy.serverSideEncryption())
+                .isEqualTo(ServerSideEncryption.AES256);
+    }
+
+    @Test
+    public void testSseS3EchoedOnMultipartComplete() throws Exception {
+        launch("s3proxy-sse-s3.conf");
+        String mkey = KEY + "-mpu";
+
+        CreateMultipartUploadResponse create = client.createMultipartUpload(
+                b -> b.bucket(CONTAINER).key(mkey)
+                        .serverSideEncryption(ServerSideEncryption.AES256));
+        String uploadId = create.uploadId();
+
+        UploadPartResponse part = client.uploadPart(
+                b -> b.bucket(CONTAINER).key(mkey).uploadId(uploadId)
+                        .partNumber(1),
+                RequestBody.fromString("hello multipart sse"));
+
+        CompletedPart cp = CompletedPart.builder()
+                .partNumber(1).eTag(part.eTag()).build();
+        var completed = client.completeMultipartUpload(
+                b -> b.bucket(CONTAINER).key(mkey).uploadId(uploadId)
+                        .multipartUpload(CompletedMultipartUpload.builder()
+                                .parts(cp).build()));
+        assertThat(completed.serverSideEncryption())
+                .isEqualTo(ServerSideEncryption.AES256);
+    }
+
+    @Test
+    public void testSseS3RejectsKms() throws Exception {
+        launch("s3proxy-sse-s3.conf");
+        assertThatThrownBy(() -> putWithSse(ServerSideEncryption.AWS_KMS))
+                .isInstanceOfSatisfying(S3Exception.class,
+                        e -> assertThat(e.statusCode()).isEqualTo(501));
+    }
+
+    @Test
+    public void testIgnoreAcceptsButDoesNotEcho() throws Exception {
+        launch("s3proxy-sse-ignore.conf");
+
+        PutObjectResponse put = putWithSse(ServerSideEncryption.AES256);
+        assertThat(put.serverSideEncryption()).isNull();
+
+        HeadObjectResponse head = client.headObject(
+                b -> b.bucket(CONTAINER).key(KEY));
+        assertThat(head.serverSideEncryption()).isNull();
+    }
+
+    @Test
+    public void testRejectReturnsNotImplemented() throws Exception {
+        launch("s3proxy-sse-reject.conf");
+        assertThatThrownBy(() -> putWithSse(ServerSideEncryption.AES256))
+                .isInstanceOfSatisfying(S3Exception.class,
+                        e -> assertThat(e.statusCode()).isEqualTo(501));
+    }
+
+    @Test
+    public void testDefaultRejectsOnNonEncryptingBackend() throws Exception {
+        // s3proxy.conf: transient backend, no SSE property, no encryption ->
+        // the derived default must be reject (never claim encryption).
+        launch("s3proxy.conf");
+        assertThatThrownBy(() -> putWithSse(ServerSideEncryption.AES256))
+                .isInstanceOfSatisfying(S3Exception.class,
+                        e -> assertThat(e.statusCode()).isEqualTo(501));
+    }
+
+    @Test
+    public void testDefaultSseS3WhenEncryptedBlobStore() throws Exception {
+        // s3proxy-encryption.conf: EncryptedBlobStore enabled, no SSE property
+        // -> the proxy really encrypts, so the default derives to sse-s3.
+        launch("s3proxy-encryption.conf");
+        PutObjectResponse put = putWithSse(ServerSideEncryption.AES256);
+        assertThat(put.serverSideEncryption())
+                .isEqualTo(ServerSideEncryption.AES256);
+        HeadObjectResponse head = client.headObject(
+                b -> b.bucket(CONTAINER).key(KEY));
+        assertThat(head.serverSideEncryption())
+                .isEqualTo(ServerSideEncryption.AES256);
+    }
+
+    @Test
+    public void testSseModeParse() {
+        assertThat(S3ProxyHandler.SseMode.parse("sse-s3"))
+                .isEqualTo(S3ProxyHandler.SseMode.SSE_S3);
+        assertThat(S3ProxyHandler.SseMode.parse("aes256"))
+                .isEqualTo(S3ProxyHandler.SseMode.SSE_S3);
+        assertThat(S3ProxyHandler.SseMode.parse("ignore"))
+                .isEqualTo(S3ProxyHandler.SseMode.IGNORE);
+        assertThat(S3ProxyHandler.SseMode.parse("reject"))
+                .isEqualTo(S3ProxyHandler.SseMode.REJECT);
+        assertThat(S3ProxyHandler.SseMode.parse(""))
+                .isEqualTo(S3ProxyHandler.SseMode.REJECT);
+        assertThat(S3ProxyHandler.SseMode.parse(null))
+                .isEqualTo(S3ProxyHandler.SseMode.REJECT);
+        assertThatThrownBy(() -> S3ProxyHandler.SseMode.parse("bogus"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/org/gaul/s3proxy/ServerSideEncryptionTest.java
+++ b/src/test/java/org/gaul/s3proxy/ServerSideEncryptionTest.java
@@ -36,7 +36,6 @@ import software.amazon.awssdk.services.s3.model.CompletedMultipartUpload;
 import software.amazon.awssdk.services.s3.model.CompletedPart;
 import software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
-import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.model.ServerSideEncryption;
@@ -95,6 +94,24 @@ public final class ServerSideEncryptionTest {
                 RequestBody.fromString("hello sse"));
     }
 
+    /** The server-side-encryption value the proxy reports for KEY on HEAD. */
+    private ServerSideEncryption headSse() {
+        return client.headObject(b -> b.bucket(CONTAINER).key(KEY))
+                .serverSideEncryption();
+    }
+
+    /** Assert that PUT with the given SSE mode is refused with 501. */
+    private void assertPutRejectedWith501(ServerSideEncryption sse) {
+        assertThatThrownBy(() -> putWithSse(sse))
+                .isInstanceOfSatisfying(S3Exception.class,
+                        e -> assertThat(e.statusCode()).isEqualTo(501));
+    }
+
+    private static void assertParses(String value,
+            S3ProxyHandler.SseMode expected) {
+        assertThat(S3ProxyHandler.SseMode.parse(value)).isEqualTo(expected);
+    }
+
     @Test
     public void testSseS3AcceptedAndEchoedOnPutHeadGet() throws Exception {
         launch("s3proxy-sse-s3.conf");
@@ -103,10 +120,7 @@ public final class ServerSideEncryptionTest {
         assertThat(put.serverSideEncryption())
                 .isEqualTo(ServerSideEncryption.AES256);
 
-        HeadObjectResponse head = client.headObject(
-                b -> b.bucket(CONTAINER).key(KEY));
-        assertThat(head.serverSideEncryption())
-                .isEqualTo(ServerSideEncryption.AES256);
+        assertThat(headSse()).isEqualTo(ServerSideEncryption.AES256);
 
         GetObjectResponse get = client.getObjectAsBytes(
                 b -> b.bucket(CONTAINER).key(KEY)).response();
@@ -154,9 +168,7 @@ public final class ServerSideEncryptionTest {
     @Test
     public void testSseS3RejectsKms() throws Exception {
         launch("s3proxy-sse-s3.conf");
-        assertThatThrownBy(() -> putWithSse(ServerSideEncryption.AWS_KMS))
-                .isInstanceOfSatisfying(S3Exception.class,
-                        e -> assertThat(e.statusCode()).isEqualTo(501));
+        assertPutRejectedWith501(ServerSideEncryption.AWS_KMS);
     }
 
     @Test
@@ -165,18 +177,13 @@ public final class ServerSideEncryptionTest {
 
         PutObjectResponse put = putWithSse(ServerSideEncryption.AES256);
         assertThat(put.serverSideEncryption()).isNull();
-
-        HeadObjectResponse head = client.headObject(
-                b -> b.bucket(CONTAINER).key(KEY));
-        assertThat(head.serverSideEncryption()).isNull();
+        assertThat(headSse()).isNull();
     }
 
     @Test
     public void testRejectReturnsNotImplemented() throws Exception {
         launch("s3proxy-sse-reject.conf");
-        assertThatThrownBy(() -> putWithSse(ServerSideEncryption.AES256))
-                .isInstanceOfSatisfying(S3Exception.class,
-                        e -> assertThat(e.statusCode()).isEqualTo(501));
+        assertPutRejectedWith501(ServerSideEncryption.AES256);
     }
 
     @Test
@@ -184,9 +191,7 @@ public final class ServerSideEncryptionTest {
         // s3proxy.conf: transient backend, no SSE property, no encryption ->
         // the derived default must be reject (never claim encryption).
         launch("s3proxy.conf");
-        assertThatThrownBy(() -> putWithSse(ServerSideEncryption.AES256))
-                .isInstanceOfSatisfying(S3Exception.class,
-                        e -> assertThat(e.statusCode()).isEqualTo(501));
+        assertPutRejectedWith501(ServerSideEncryption.AES256);
     }
 
     @Test
@@ -197,26 +202,17 @@ public final class ServerSideEncryptionTest {
         PutObjectResponse put = putWithSse(ServerSideEncryption.AES256);
         assertThat(put.serverSideEncryption())
                 .isEqualTo(ServerSideEncryption.AES256);
-        HeadObjectResponse head = client.headObject(
-                b -> b.bucket(CONTAINER).key(KEY));
-        assertThat(head.serverSideEncryption())
-                .isEqualTo(ServerSideEncryption.AES256);
+        assertThat(headSse()).isEqualTo(ServerSideEncryption.AES256);
     }
 
     @Test
     public void testSseModeParse() {
-        assertThat(S3ProxyHandler.SseMode.parse("sse-s3"))
-                .isEqualTo(S3ProxyHandler.SseMode.SSE_S3);
-        assertThat(S3ProxyHandler.SseMode.parse("aes256"))
-                .isEqualTo(S3ProxyHandler.SseMode.SSE_S3);
-        assertThat(S3ProxyHandler.SseMode.parse("ignore"))
-                .isEqualTo(S3ProxyHandler.SseMode.IGNORE);
-        assertThat(S3ProxyHandler.SseMode.parse("reject"))
-                .isEqualTo(S3ProxyHandler.SseMode.REJECT);
-        assertThat(S3ProxyHandler.SseMode.parse(""))
-                .isEqualTo(S3ProxyHandler.SseMode.REJECT);
-        assertThat(S3ProxyHandler.SseMode.parse(null))
-                .isEqualTo(S3ProxyHandler.SseMode.REJECT);
+        assertParses("sse-s3", S3ProxyHandler.SseMode.SSE_S3);
+        assertParses("aes256", S3ProxyHandler.SseMode.SSE_S3);
+        assertParses("ignore", S3ProxyHandler.SseMode.IGNORE);
+        assertParses("reject", S3ProxyHandler.SseMode.REJECT);
+        assertParses("", S3ProxyHandler.SseMode.REJECT);
+        assertParses(null, S3ProxyHandler.SseMode.REJECT);
         assertThatThrownBy(() -> S3ProxyHandler.SseMode.parse("bogus"))
                 .isInstanceOf(IllegalArgumentException.class);
     }

--- a/src/test/resources/s3proxy-sse-ignore.conf
+++ b/src/test/resources/s3proxy-sse-ignore.conf
@@ -1,0 +1,12 @@
+s3proxy.endpoint=http://127.0.0.1:0
+s3proxy.secure-endpoint=https://127.0.0.1:0
+s3proxy.authorization=aws-v2-or-v4
+s3proxy.identity=local-identity
+s3proxy.credential=local-credential
+s3proxy.keystore-path=keystore.jks
+s3proxy.keystore-password=password
+s3proxy.server-side-encryption=ignore
+
+jclouds.provider=transient
+jclouds.identity=remote-identity
+jclouds.credential=remote-credential

--- a/src/test/resources/s3proxy-sse-reject.conf
+++ b/src/test/resources/s3proxy-sse-reject.conf
@@ -1,0 +1,12 @@
+s3proxy.endpoint=http://127.0.0.1:0
+s3proxy.secure-endpoint=https://127.0.0.1:0
+s3proxy.authorization=aws-v2-or-v4
+s3proxy.identity=local-identity
+s3proxy.credential=local-credential
+s3proxy.keystore-path=keystore.jks
+s3proxy.keystore-password=password
+s3proxy.server-side-encryption=reject
+
+jclouds.provider=transient
+jclouds.identity=remote-identity
+jclouds.credential=remote-credential

--- a/src/test/resources/s3proxy-sse-s3.conf
+++ b/src/test/resources/s3proxy-sse-s3.conf
@@ -1,0 +1,12 @@
+s3proxy.endpoint=http://127.0.0.1:0
+s3proxy.secure-endpoint=https://127.0.0.1:0
+s3proxy.authorization=aws-v2-or-v4
+s3proxy.identity=local-identity
+s3proxy.credential=local-credential
+s3proxy.keystore-path=keystore.jks
+s3proxy.keystore-password=password
+s3proxy.server-side-encryption=sse-s3
+
+jclouds.provider=transient
+jclouds.identity=remote-identity
+jclouds.credential=remote-credential


### PR DESCRIPTION
Partially resolves #402 — this is **Phase 1 (SSE-S3 accept + echo)** from your comment on that issue. Opening as a draft to check the approach before going further.

## What this does
Adds an `s3proxy.server-side-encryption` property governing the `x-amz-server-side-encryption` request header:

- **Default reflects what the backend can truthfully claim** — `sse-s3` on stores that always encrypt at rest (S3 / Azure / GCS, via `Quirks.SERVER_SIDE_ENCRYPTION_AT_REST`) or when `s3proxy.encrypted-blobstore` is enabled; otherwise `reject`. This follows the honesty point in the issue ("gate the echo on a real backend or on `EncryptedBlobStore` being enabled rather than assert encryption that is not happening").
- **Overridable** via the property: `reject` | `ignore` | `sse-s3`.
- In `sse-s3` mode, `AES256` is accepted and **echoed on PUT / HEAD / GET / copy / complete**.
- `aws:kms` and SSE-C (`x-amz-server-side-encryption-customer-*`) are **always rejected** with `501`, so a caller-supplied key is never silently dropped.

The header is added to `SUPPORTED_X_AMZ_HEADERS` (building on the allowlist idea in jiffysrc@fc8547f) and handled explicitly rather than via the unknown-header path.

## Tests
New `ServerSideEncryptionTest` (9 cases): accept + echo on PUT/HEAD/GET/copy/complete; `ignore` accepts without echo; `reject` and `aws:kms`/SSE-C → 501; derived default = reject on transient and sse-s3 under `encrypted-blobstore`; `SseMode` parsing. Full `mvn verify -Pjdeps` is green (checkstyle, spotbugs, error-prone/NullAway, jdeps, 413 tests).

## Deliberately out of scope (later phases from #402)
- **Per-object persistence.** The echo is currently gated on the configured/derived mode rather than a persisted per-object marker. Happy to switch to an internal `s3proxy_*` metadata key (filtered from HEAD/list) if you prefer that shape.
- **SSE-C** for real (Phase 2), **bucket default encryption `?encryption`** (Phase 3), **SSE-KMS** (Phase 4).
- I added a focused JUnit test rather than enabling the existing `sse_s3` ceph tests in `run-s3-tests.sh` — glad to flip those on instead/as well.

Feedback welcome on the two design forks (mode-gated vs persisted marker; and whether the config knob is wanted at all vs a pure capability gate).

Generated with [Claude Code](https://claude.com/claude-code)
