### PR TITLE
Answer server-side encryption where the store can encrypt

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ S3Proxy has broad compatibility with the S3 API, however, it does not support:
 * hosting static websites
 * object lock, including legal hold and retention
 * object ownership controls
-* object server-side encryption, see [#402](https://github.com/gaul/s3proxy/issues/402)
+* object server-side encryption on backends other than aws-s3-sdk, and SSE-C on any backend, see [#402](https://github.com/gaul/s3proxy/issues/402)
 * object tagging
 * object versioning on backends other than aws-s3-sdk, see [#74](https://github.com/gaul/s3proxy/issues/74)
 * paginating ListParts with `part-number-marker`

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ S3Proxy has broad compatibility with the S3 API, however, it does not support:
 * hosting static websites
 * object lock, including legal hold and retention
 * object ownership controls
-* object server-side encryption, see [#402](https://github.com/gaul/s3proxy/issues/402)
+* object server-side encryption with a customer-provided key (SSE-C), see [#402](https://github.com/gaul/s3proxy/issues/402)
 * object tagging
 * paginating ListParts with `part-number-marker`
 * public access block
@@ -170,6 +170,7 @@ Some limitations depend on the storage backend:
 | `UploadPartCopy` streams the data through S3Proxy instead of copying it on the backend | `filesystem`, `transient`, `openstack-swift`, `sftp` |
 | conditional PUT refuses `If-Match`, honoring only `If-None-Match: *` | `openstack-swift` |
 | no object versioning, see [#74](https://github.com/gaul/s3proxy/issues/74) | `azureblob`, `filesystem`, `google-cloud-storage`, `openstack-swift`, `sftp` |
+| no server-side encryption, see [#402](https://github.com/gaul/s3proxy/issues/402) | `azureblob`, `filesystem`, `google-cloud-storage`, `openstack-swift`, `sftp` |
 
 The two backends that do version objects come by it differently.  `aws-s3`
 passes the requests through to a service that already versions, while
@@ -177,6 +178,15 @@ passes the requests through to a service that already versions, while
 as a hidden object.  `filesystem` shares that implementation and declines it:
 its versions would outlive the process, settling a layout on disk that
 S3Proxy would owe its users from then on.
+
+Server-side encryption divides the same two from the rest, and divides the
+two nio2 stores on the same line.  `aws-s3` forwards the header family to a
+service that encrypts, while `transient` answers it itself: what it holds
+rests in a filesystem that dies with the process, so an object's encryption
+is the headers and nothing besides, which is all S3 lets a caller observe of
+SSE-S3 anyway.  `filesystem` writes to a real disk, where reporting AES256
+over plaintext someone could go and read would be a claim S3Proxy has no
+business making, so it refuses those headers instead.
 
 Two backends copy a part on the server but fall back to streaming it through
 S3Proxy in one case each: `google-cloud-storage` for a range covering less

--- a/src/main/java/org/gaul/s3proxy/AliasBlobStore.java
+++ b/src/main/java/org/gaul/s3proxy/AliasBlobStore.java
@@ -238,7 +238,7 @@ public final class AliasBlobStore extends ForwardingBlobStore {
                 request.toBuilder()
                         .bucket(getContainer(request.bucket()))
                         .build());
-        return new MultipartUpload(mpu.id(), request);
+        return new MultipartUpload(mpu.id(), request, mpu.response());
     }
 
     @Override

--- a/src/main/java/org/gaul/s3proxy/AliasBlobStore.java
+++ b/src/main/java/org/gaul/s3proxy/AliasBlobStore.java
@@ -241,7 +241,7 @@ public final class AliasBlobStore extends ForwardingBlobStore {
                 request.toBuilder()
                         .bucket(getContainer(request.bucket()))
                         .build());
-        return new MultipartUpload(mpu.id(), request);
+        return new MultipartUpload(mpu.id(), request, mpu.response());
     }
 
     @Override

--- a/src/main/java/org/gaul/s3proxy/AwsHttpHeaders.java
+++ b/src/main/java/org/gaul/s3proxy/AwsHttpHeaders.java
@@ -49,6 +49,14 @@ final class AwsHttpHeaders {
     static final String OBJECT_ATTRIBUTES = "x-amz-object-attributes";
     static final String REQUEST_ID = "x-amz-request-id";
     static final String SDK_CHECKSUM_ALGORITHM = "x-amz-sdk-checksum-algorithm";
+    static final String SERVER_SIDE_ENCRYPTION =
+            "x-amz-server-side-encryption";
+    static final String SERVER_SIDE_ENCRYPTION_AWS_KMS_KEY_ID =
+            "x-amz-server-side-encryption-aws-kms-key-id";
+    static final String SERVER_SIDE_ENCRYPTION_BUCKET_KEY_ENABLED =
+            "x-amz-server-side-encryption-bucket-key-enabled";
+    static final String SERVER_SIDE_ENCRYPTION_CONTEXT =
+            "x-amz-server-side-encryption-context";
     static final String STORAGE_CLASS = "x-amz-storage-class";
     static final String TRAILER = "x-amz-trailer";
     static final String TRANSFER_ENCODING = "x-amz-te";

--- a/src/main/java/org/gaul/s3proxy/AwsHttpHeaders.java
+++ b/src/main/java/org/gaul/s3proxy/AwsHttpHeaders.java
@@ -52,6 +52,14 @@ final class AwsHttpHeaders {
     static final String OBJECT_ATTRIBUTES = "x-amz-object-attributes";
     static final String REQUEST_ID = "x-amz-request-id";
     static final String SDK_CHECKSUM_ALGORITHM = "x-amz-sdk-checksum-algorithm";
+    static final String SERVER_SIDE_ENCRYPTION =
+            "x-amz-server-side-encryption";
+    static final String SERVER_SIDE_ENCRYPTION_AWS_KMS_KEY_ID =
+            "x-amz-server-side-encryption-aws-kms-key-id";
+    static final String SERVER_SIDE_ENCRYPTION_BUCKET_KEY_ENABLED =
+            "x-amz-server-side-encryption-bucket-key-enabled";
+    static final String SERVER_SIDE_ENCRYPTION_CONTEXT =
+            "x-amz-server-side-encryption-context";
     static final String STORAGE_CLASS = "x-amz-storage-class";
     static final String TRAILER = "x-amz-trailer";
     static final String TRANSFER_ENCODING = "x-amz-te";

--- a/src/main/java/org/gaul/s3proxy/EncryptedBlobStore.java
+++ b/src/main/java/org/gaul/s3proxy/EncryptedBlobStore.java
@@ -518,7 +518,8 @@ public final class EncryptedBlobStore extends ForwardingBlobStore {
         }
         return new MultipartUpload(mpu.id(), mpu.request().toBuilder()
             .key(blobNameWithSuffix(blobName))
-            .build());
+            .build(),
+            mpu.response());
     }
 
     @Override

--- a/src/main/java/org/gaul/s3proxy/EncryptedBlobStore.java
+++ b/src/main/java/org/gaul/s3proxy/EncryptedBlobStore.java
@@ -523,7 +523,8 @@ public final class EncryptedBlobStore extends ForwardingBlobStore {
         }
         return new MultipartUpload(mpu.id(), mpu.request().toBuilder()
             .key(blobNameWithSuffix(blobName))
-            .build());
+            .build(),
+            mpu.response());
     }
 
     @Override

--- a/src/main/java/org/gaul/s3proxy/PrefixBlobStore.java
+++ b/src/main/java/org/gaul/s3proxy/PrefixBlobStore.java
@@ -142,7 +142,8 @@ public final class PrefixBlobStore extends ForwardingBlobStore {
                 upload.request().toBuilder()
                         .key(trimPrefix(upload.containerName(),
                                 upload.blobName()))
-                        .build());
+                        .build(),
+                upload.response());
     }
 
     private ListObjectsV2Request applyPrefix(String container,

--- a/src/main/java/org/gaul/s3proxy/PrefixBlobStore.java
+++ b/src/main/java/org/gaul/s3proxy/PrefixBlobStore.java
@@ -144,7 +144,8 @@ public final class PrefixBlobStore extends ForwardingBlobStore {
                 upload.request().toBuilder()
                         .key(trimPrefix(upload.containerName(),
                                 upload.blobName()))
-                        .build());
+                        .build(),
+                upload.response());
     }
 
     private ListObjectsV2Request applyPrefix(String container,

--- a/src/main/java/org/gaul/s3proxy/RegexBlobStore.java
+++ b/src/main/java/org/gaul/s3proxy/RegexBlobStore.java
@@ -237,7 +237,8 @@ public final class RegexBlobStore extends ForwardingBlobStore {
         }
         return new MultipartUpload(mpu.id(), mpu.request().toBuilder()
                 .key(newName)
-                .build());
+                .build(),
+                mpu.response());
     }
 
 

--- a/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
@@ -290,6 +290,10 @@ public class S3ProxyHandler {
             AwsHttpHeaders.METADATA_DIRECTIVE,
             AwsHttpHeaders.OBJECT_ATTRIBUTES,
             AwsHttpHeaders.SDK_CHECKSUM_ALGORITHM,  // TODO: ignoring header
+            AwsHttpHeaders.SERVER_SIDE_ENCRYPTION,
+            AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_AWS_KMS_KEY_ID,
+            AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_BUCKET_KEY_ENABLED,
+            AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_CONTEXT,
             AwsHttpHeaders.STORAGE_CLASS,
             AwsHttpHeaders.TRAILER,
             AwsHttpHeaders.TRANSFER_ENCODING,  // TODO: ignoring header
@@ -1078,6 +1082,7 @@ public class S3ProxyHandler {
         }
 
         checkVersionId(request, blobStore);
+        checkServerSideEncryption(request, blobStore);
 
         if (path.length > 2) {
             checkReservedBlobName(path[2]);
@@ -3137,6 +3142,69 @@ public class S3ProxyHandler {
     }
 
     /**
+     * Vet the x-amz-server-side-encryption request family: only a store
+     * that forwards it to a backend performing the encryption may see it,
+     * on any method, as before these headers were understood at all.
+     * SSE-C stays refused everywhere by its headers' absence from
+     * SUPPORTED_X_AMZ_HEADERS -- silently dropping a caller's key would
+     * claim an encryption nobody performed.
+     */
+    private static void checkServerSideEncryption(HttpServletRequest request,
+            BlobStore blobStore) {
+        if (blobStore.supportsServerSideEncryption()) {
+            return;
+        }
+        if (request.getHeader(AwsHttpHeaders.SERVER_SIDE_ENCRYPTION) != null ||
+                request.getHeader(AwsHttpHeaders
+                        .SERVER_SIDE_ENCRYPTION_AWS_KMS_KEY_ID) != null ||
+                request.getHeader(AwsHttpHeaders
+                        .SERVER_SIDE_ENCRYPTION_BUCKET_KEY_ENABLED) != null ||
+                request.getHeader(AwsHttpHeaders
+                        .SERVER_SIDE_ENCRYPTION_CONTEXT) != null) {
+            throw new S3ProxyException(S3ErrorCode.NOT_IMPLEMENTED,
+                    "Server-side encryption is not supported.");
+        }
+    }
+
+    /**
+     * The x-amz-server-side-encryption-bucket-key-enabled request header
+     * as the SDK's Boolean, or null when the request does not state one --
+     * an explicit false and an absent header differ, since only the
+     * former overrides the backend bucket's own configuration.
+     */
+    @Nullable
+    private static Boolean parseBucketKeyEnabled(HttpServletRequest request) {
+        String value = request.getHeader(
+                AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_BUCKET_KEY_ENABLED);
+        return value == null ? null : Boolean.valueOf(value);
+    }
+
+    /** Report the encryption the backend answered, field by field. */
+    private static void addServerSideEncryptionHeaders(
+            HttpServletResponse response, @Nullable String algorithm,
+            @Nullable String kmsKeyId, @Nullable String kmsContext,
+            @Nullable Boolean bucketKeyEnabled) {
+        if (algorithm != null) {
+            response.addHeader(AwsHttpHeaders.SERVER_SIDE_ENCRYPTION,
+                    algorithm);
+        }
+        if (kmsKeyId != null) {
+            response.addHeader(
+                    AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_AWS_KMS_KEY_ID,
+                    kmsKeyId);
+        }
+        if (kmsContext != null) {
+            response.addHeader(AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_CONTEXT,
+                    kmsContext);
+        }
+        if (bucketKeyEnabled != null) {
+            response.addHeader(
+                    AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_BUCKET_KEY_ENABLED,
+                    bucketKeyEnabled.toString());
+        }
+    }
+
+    /**
      * Vet a partNumber read.  S3 answers with that part of a multipart
      * object, or with the whole object when the object has just one part.
      * s3proxy does not record where the parts ended once the upload
@@ -3626,6 +3694,16 @@ public class S3ProxyHandler {
                     Instant.ofEpochMilli(ifUnmodifiedSince));
         }
 
+        // The destination's encryption, applied whatever the metadata
+        // directive says, as on S3.
+        copyRequest.serverSideEncryption(
+                request.getHeader(AwsHttpHeaders.SERVER_SIDE_ENCRYPTION))
+                .ssekmsKeyId(request.getHeader(
+                        AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_AWS_KMS_KEY_ID))
+                .ssekmsEncryptionContext(request.getHeader(
+                        AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_CONTEXT))
+                .bucketKeyEnabled(parseBucketKeyEnabled(request));
+
         if (replaceMetadata) {
             copyRequest.metadataDirective(MetadataDirective.REPLACE);
             var userMetadata = ImmutableMap.<String, String>builder();
@@ -3682,6 +3760,11 @@ public class S3ProxyHandler {
         if (destVersionId != null) {
             response.addHeader(AwsHttpHeaders.VERSION_ID, destVersionId);
         }
+        addServerSideEncryptionHeaders(response,
+                copyResult.serverSideEncryptionAsString(),
+                copyResult.ssekmsKeyId(),
+                copyResult.ssekmsEncryptionContext(),
+                copyResult.bucketKeyEnabled());
         try (Writer writer = response.getWriter()) {
             response.setContentType(XML_CONTENT_TYPE);
             XMLStreamWriter xml = xmlOutputFactory.createXMLStreamWriter(
@@ -3870,6 +3953,16 @@ public class S3ProxyHandler {
             }
         }
 
+        // Rides verbatim: the backend performs the encryption and judges
+        // the values, and its answer rides back on the response below.
+        putRequest.serverSideEncryption(
+                request.getHeader(AwsHttpHeaders.SERVER_SIDE_ENCRYPTION))
+                .ssekmsKeyId(request.getHeader(
+                        AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_AWS_KMS_KEY_ID))
+                .ssekmsEncryptionContext(request.getHeader(
+                        AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_CONTEXT))
+                .bucketKeyEnabled(parseBucketKeyEnabled(request));
+
         var contentHeaders = parseContentMetadata(request, checksum,
                 checksumValue);
         putRequest.cacheControl(contentHeaders.cacheControl())
@@ -3896,6 +3989,9 @@ public class S3ProxyHandler {
         if (versionId != null) {
             response.addHeader(AwsHttpHeaders.VERSION_ID, versionId);
         }
+        addServerSideEncryptionHeaders(response,
+                result.serverSideEncryptionAsString(), result.ssekmsKeyId(),
+                result.ssekmsEncryptionContext(), result.bucketKeyEnabled());
         if (checksum != null) {
             response.addHeader(checksum.header(), checksumValue);
         }
@@ -4380,7 +4476,14 @@ public class S3ProxyHandler {
                 .contentLanguage(contentHeaders.contentLanguage())
                 .contentType(contentHeaders.contentType())
                 .expires(contentHeaders.expires())
-                .metadata(contentHeaders.userMetadata());
+                .metadata(contentHeaders.userMetadata())
+                .serverSideEncryption(
+                        request.getHeader(AwsHttpHeaders.SERVER_SIDE_ENCRYPTION))
+                .ssekmsKeyId(request.getHeader(
+                        AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_AWS_KMS_KEY_ID))
+                .ssekmsEncryptionContext(request.getHeader(
+                        AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_CONTEXT))
+                .bucketKeyEnabled(parseBucketKeyEnabled(request));
 
         StorageClass parsedStorageClass = null;
         String storageClass = request.getHeader(AwsHttpHeaders.STORAGE_CLASS);
@@ -4465,6 +4568,14 @@ public class S3ProxyHandler {
                     mpuAlgorithm.name());
             response.addHeader(AwsHttpHeaders.CHECKSUM_TYPE,
                     fullObject ? FULL_OBJECT : COMPOSITE);
+        }
+        var createResponse = mpu.response();
+        if (createResponse != null) {
+            addServerSideEncryptionHeaders(response,
+                    createResponse.serverSideEncryptionAsString(),
+                    createResponse.ssekmsKeyId(),
+                    createResponse.ssekmsEncryptionContext(),
+                    createResponse.bucketKeyEnabled());
         }
         try (Writer writer = response.getWriter()) {
             response.setContentType(XML_CONTENT_TYPE);
@@ -4757,6 +4868,16 @@ public class S3ProxyHandler {
         if (completedResult != null && completedResult.versionId() != null) {
             response.addHeader(AwsHttpHeaders.VERSION_ID,
                     completedResult.versionId());
+        }
+        // The asynchronous completion below commits the response before the
+        // outcome is known, so only the synchronous path can report the
+        // encryption -- and a store that supports it always takes it, since
+        // it also supports versioning.
+        if (completedResult != null) {
+            addServerSideEncryptionHeaders(response,
+                    completedResult.serverSideEncryptionAsString(),
+                    completedResult.ssekmsKeyId(), /*kmsContext=*/ null,
+                    completedResult.bucketKeyEnabled());
         }
         try (PrintWriter writer = response.getWriter()) {
             response.setStatus(HttpServletResponse.SC_OK);
@@ -5709,15 +5830,24 @@ public class S3ProxyHandler {
 
         long contentLength = requireNonNull(blobMetadata.contentLength());
 
+        UploadPartResponse part;
         try (InputStream is = blob) {
-            UploadPartResponse part = blobStore.uploadMultipartPart(mpu,
-                    partNumber, is, contentLength, null);
+            part = blobStore.uploadMultipartPart(mpu, partNumber, is,
+                    contentLength, null);
             eTag = part.eTag();
         }
 
+        // The part was written by the same call a plain part upload uses, so
+        // it rests under the upload's encryption and reports it the same way;
+        // emulating the copy must not lose what the write already answered.
         writeCopyPartResponse(request, response,
                 SdkResponses.copiedPart(eTag, lastModified,
-                        blobMetadata.versionId()));
+                        blobMetadata.versionId()).toBuilder()
+                        .serverSideEncryption(
+                                part.serverSideEncryptionAsString())
+                        .ssekmsKeyId(part.ssekmsKeyId())
+                        .bucketKeyEnabled(part.bucketKeyEnabled())
+                        .build());
     }
 
     private void writeCopyPartResponse(HttpServletRequest request,
@@ -5730,6 +5860,9 @@ public class S3ProxyHandler {
             response.addHeader(AwsHttpHeaders.COPY_SOURCE_VERSION_ID,
                     copySourceVersionId);
         }
+        addServerSideEncryptionHeaders(response,
+                part.serverSideEncryptionAsString(), part.ssekmsKeyId(),
+                /*kmsContext=*/ null, part.bucketKeyEnabled());
         try (Writer writer = response.getWriter()) {
             response.setContentType(XML_CONTENT_TYPE);
             XMLStreamWriter xml = xmlOutputFactory.createXMLStreamWriter(
@@ -5852,6 +5985,9 @@ public class S3ProxyHandler {
         if (checksum != null) {
             response.addHeader(checksum.header(), checksumValue);
         }
+        addServerSideEncryptionHeaders(response,
+                part.serverSideEncryptionAsString(), part.ssekmsKeyId(),
+                /*kmsContext=*/ null, part.bucketKeyEnabled());
 
         addCorsResponseHeader(request, response);
     }
@@ -5928,6 +6064,10 @@ public class S3ProxyHandler {
         if (storageClass != null) {
             response.addHeader(AwsHttpHeaders.STORAGE_CLASS, storageClass);
         }
+        addServerSideEncryptionHeaders(response,
+                metadata.serverSideEncryptionAsString(),
+                metadata.ssekmsKeyId(), /*kmsContext=*/ null,
+                metadata.bucketKeyEnabled());
         FlexChecksum storedChecksum = null;
         String storedChecksumValue = null;
         for (var entry : metadata.metadata().entrySet()) {

--- a/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
@@ -281,6 +281,10 @@ public class S3ProxyHandler {
             AwsHttpHeaders.METADATA_DIRECTIVE,
             AwsHttpHeaders.OBJECT_ATTRIBUTES,
             AwsHttpHeaders.SDK_CHECKSUM_ALGORITHM,  // TODO: ignoring header
+            AwsHttpHeaders.SERVER_SIDE_ENCRYPTION,
+            AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_AWS_KMS_KEY_ID,
+            AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_BUCKET_KEY_ENABLED,
+            AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_CONTEXT,
             AwsHttpHeaders.STORAGE_CLASS,
             AwsHttpHeaders.TRAILER,
             AwsHttpHeaders.TRANSFER_ENCODING,  // TODO: ignoring header
@@ -1028,6 +1032,7 @@ public class S3ProxyHandler {
         }
 
         checkVersionId(request, blobStore);
+        checkServerSideEncryption(request, blobStore);
 
         String uploadId = request.getParameter("uploadId");
 
@@ -2959,6 +2964,69 @@ public class S3ProxyHandler {
     }
 
     /**
+     * Vet the x-amz-server-side-encryption request family: only a store
+     * that forwards it to a backend performing the encryption may see it,
+     * on any method, as before these headers were understood at all.
+     * SSE-C stays refused everywhere by its headers' absence from
+     * SUPPORTED_X_AMZ_HEADERS -- silently dropping a caller's key would
+     * claim an encryption nobody performed.
+     */
+    private static void checkServerSideEncryption(HttpServletRequest request,
+            BlobStore blobStore) {
+        if (blobStore.supportsServerSideEncryption()) {
+            return;
+        }
+        if (request.getHeader(AwsHttpHeaders.SERVER_SIDE_ENCRYPTION) != null ||
+                request.getHeader(AwsHttpHeaders
+                        .SERVER_SIDE_ENCRYPTION_AWS_KMS_KEY_ID) != null ||
+                request.getHeader(AwsHttpHeaders
+                        .SERVER_SIDE_ENCRYPTION_BUCKET_KEY_ENABLED) != null ||
+                request.getHeader(AwsHttpHeaders
+                        .SERVER_SIDE_ENCRYPTION_CONTEXT) != null) {
+            throw new S3ProxyException(S3ErrorCode.NOT_IMPLEMENTED,
+                    "Server-side encryption is not supported.");
+        }
+    }
+
+    /**
+     * The x-amz-server-side-encryption-bucket-key-enabled request header
+     * as the SDK's Boolean, or null when the request does not state one --
+     * an explicit false and an absent header differ, since only the
+     * former overrides the backend bucket's own configuration.
+     */
+    @Nullable
+    private static Boolean parseBucketKeyEnabled(HttpServletRequest request) {
+        String value = request.getHeader(
+                AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_BUCKET_KEY_ENABLED);
+        return value == null ? null : Boolean.valueOf(value);
+    }
+
+    /** Report the encryption the backend answered, field by field. */
+    private static void addServerSideEncryptionHeaders(
+            HttpServletResponse response, @Nullable String algorithm,
+            @Nullable String kmsKeyId, @Nullable String kmsContext,
+            @Nullable Boolean bucketKeyEnabled) {
+        if (algorithm != null) {
+            response.addHeader(AwsHttpHeaders.SERVER_SIDE_ENCRYPTION,
+                    algorithm);
+        }
+        if (kmsKeyId != null) {
+            response.addHeader(
+                    AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_AWS_KMS_KEY_ID,
+                    kmsKeyId);
+        }
+        if (kmsContext != null) {
+            response.addHeader(AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_CONTEXT,
+                    kmsContext);
+        }
+        if (bucketKeyEnabled != null) {
+            response.addHeader(
+                    AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_BUCKET_KEY_ENABLED,
+                    bucketKeyEnabled.toString());
+        }
+    }
+
+    /**
      * Vet a partNumber read.  S3 answers with that part of a multipart
      * object, or with the whole object when the object has just one part.
      * s3proxy does not record where the parts ended once the upload
@@ -3445,6 +3513,16 @@ public class S3ProxyHandler {
                     Instant.ofEpochMilli(ifUnmodifiedSince));
         }
 
+        // The destination's encryption, applied whatever the metadata
+        // directive says, as on S3.
+        copyRequest.serverSideEncryption(
+                request.getHeader(AwsHttpHeaders.SERVER_SIDE_ENCRYPTION))
+                .ssekmsKeyId(request.getHeader(
+                        AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_AWS_KMS_KEY_ID))
+                .ssekmsEncryptionContext(request.getHeader(
+                        AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_CONTEXT))
+                .bucketKeyEnabled(parseBucketKeyEnabled(request));
+
         if (replaceMetadata) {
             copyRequest.metadataDirective(MetadataDirective.REPLACE);
             var userMetadata = ImmutableMap.<String, String>builder();
@@ -3501,6 +3579,11 @@ public class S3ProxyHandler {
         if (destVersionId != null) {
             response.addHeader(AwsHttpHeaders.VERSION_ID, destVersionId);
         }
+        addServerSideEncryptionHeaders(response,
+                copyResult.serverSideEncryptionAsString(),
+                copyResult.ssekmsKeyId(),
+                copyResult.ssekmsEncryptionContext(),
+                copyResult.bucketKeyEnabled());
         try (Writer writer = response.getWriter()) {
             response.setContentType(XML_CONTENT_TYPE);
             XMLStreamWriter xml = xmlOutputFactory.createXMLStreamWriter(
@@ -3689,6 +3772,16 @@ public class S3ProxyHandler {
             }
         }
 
+        // Rides verbatim: the backend performs the encryption and judges
+        // the values, and its answer rides back on the response below.
+        putRequest.serverSideEncryption(
+                request.getHeader(AwsHttpHeaders.SERVER_SIDE_ENCRYPTION))
+                .ssekmsKeyId(request.getHeader(
+                        AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_AWS_KMS_KEY_ID))
+                .ssekmsEncryptionContext(request.getHeader(
+                        AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_CONTEXT))
+                .bucketKeyEnabled(parseBucketKeyEnabled(request));
+
         var contentHeaders = parseContentMetadata(request, checksum,
                 checksumValue);
         putRequest.cacheControl(contentHeaders.cacheControl())
@@ -3715,6 +3808,9 @@ public class S3ProxyHandler {
         if (versionId != null) {
             response.addHeader(AwsHttpHeaders.VERSION_ID, versionId);
         }
+        addServerSideEncryptionHeaders(response,
+                result.serverSideEncryptionAsString(), result.ssekmsKeyId(),
+                result.ssekmsEncryptionContext(), result.bucketKeyEnabled());
         if (checksum != null) {
             response.addHeader(checksum.header(), checksumValue);
         }
@@ -4196,7 +4292,14 @@ public class S3ProxyHandler {
                 .contentLanguage(contentHeaders.contentLanguage())
                 .contentType(contentHeaders.contentType())
                 .expires(contentHeaders.expires())
-                .metadata(contentHeaders.userMetadata());
+                .metadata(contentHeaders.userMetadata())
+                .serverSideEncryption(
+                        request.getHeader(AwsHttpHeaders.SERVER_SIDE_ENCRYPTION))
+                .ssekmsKeyId(request.getHeader(
+                        AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_AWS_KMS_KEY_ID))
+                .ssekmsEncryptionContext(request.getHeader(
+                        AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_CONTEXT))
+                .bucketKeyEnabled(parseBucketKeyEnabled(request));
 
         StorageClass parsedStorageClass = null;
         String storageClass = request.getHeader(AwsHttpHeaders.STORAGE_CLASS);
@@ -4281,6 +4384,14 @@ public class S3ProxyHandler {
                     mpuAlgorithm.name());
             response.addHeader(AwsHttpHeaders.CHECKSUM_TYPE,
                     fullObject ? FULL_OBJECT : COMPOSITE);
+        }
+        var createResponse = mpu.response();
+        if (createResponse != null) {
+            addServerSideEncryptionHeaders(response,
+                    createResponse.serverSideEncryptionAsString(),
+                    createResponse.ssekmsKeyId(),
+                    createResponse.ssekmsEncryptionContext(),
+                    createResponse.bucketKeyEnabled());
         }
         try (Writer writer = response.getWriter()) {
             response.setContentType(XML_CONTENT_TYPE);
@@ -4574,6 +4685,16 @@ public class S3ProxyHandler {
         if (completedResult != null && completedResult.versionId() != null) {
             response.addHeader(AwsHttpHeaders.VERSION_ID,
                     completedResult.versionId());
+        }
+        // The asynchronous completion below commits the response before the
+        // outcome is known, so only the synchronous path can report the
+        // encryption -- and a store that supports it always takes it, since
+        // it also supports versioning.
+        if (completedResult != null) {
+            addServerSideEncryptionHeaders(response,
+                    completedResult.serverSideEncryptionAsString(),
+                    completedResult.ssekmsKeyId(), /*kmsContext=*/ null,
+                    completedResult.bucketKeyEnabled());
         }
         try (PrintWriter writer = response.getWriter()) {
             response.setStatus(HttpServletResponse.SC_OK);
@@ -5545,6 +5666,9 @@ public class S3ProxyHandler {
             response.addHeader(AwsHttpHeaders.COPY_SOURCE_VERSION_ID,
                     copySourceVersionId);
         }
+        addServerSideEncryptionHeaders(response,
+                part.serverSideEncryptionAsString(), part.ssekmsKeyId(),
+                /*kmsContext=*/ null, part.bucketKeyEnabled());
         try (Writer writer = response.getWriter()) {
             response.setContentType(XML_CONTENT_TYPE);
             XMLStreamWriter xml = xmlOutputFactory.createXMLStreamWriter(
@@ -5667,6 +5791,9 @@ public class S3ProxyHandler {
         if (checksum != null) {
             response.addHeader(checksum.header(), checksumValue);
         }
+        addServerSideEncryptionHeaders(response,
+                part.serverSideEncryptionAsString(), part.ssekmsKeyId(),
+                /*kmsContext=*/ null, part.bucketKeyEnabled());
 
         addCorsResponseHeader(request, response);
     }
@@ -5743,6 +5870,10 @@ public class S3ProxyHandler {
         if (storageClass != null) {
             response.addHeader(AwsHttpHeaders.STORAGE_CLASS, storageClass);
         }
+        addServerSideEncryptionHeaders(response,
+                metadata.serverSideEncryptionAsString(),
+                metadata.ssekmsKeyId(), /*kmsContext=*/ null,
+                metadata.bucketKeyEnabled());
         FlexChecksum storedChecksum = null;
         String storedChecksumValue = null;
         for (var entry : metadata.metadata().entrySet()) {

--- a/src/main/java/org/gaul/s3proxy/awssdk/AwsS3SdkBlobStore.java
+++ b/src/main/java/org/gaul/s3proxy/awssdk/AwsS3SdkBlobStore.java
@@ -487,6 +487,11 @@ public final class AwsS3SdkBlobStore implements BlobStore {
     }
 
     @Override
+    public boolean supportsServerSideEncryption() {
+        return true;
+    }
+
+    @Override
     @Nullable
     public BucketVersioningStatus getContainerVersioning(String container) {
         try {
@@ -600,7 +605,7 @@ public final class AwsS3SdkBlobStore implements BlobStore {
             CreateMultipartUploadRequest request) {
         try {
             var response = s3Client.createMultipartUpload(request);
-            return new MultipartUpload(response.uploadId(), request);
+            return new MultipartUpload(response.uploadId(), request, response);
         } catch (S3Exception e) {
             throw propagate(e, request.bucket(), request.key());
         }

--- a/src/main/java/org/gaul/s3proxy/awssdk/AwsS3SdkBlobStore.java
+++ b/src/main/java/org/gaul/s3proxy/awssdk/AwsS3SdkBlobStore.java
@@ -461,6 +461,11 @@ public final class AwsS3SdkBlobStore implements BlobStore {
     }
 
     @Override
+    public boolean supportsServerSideEncryption() {
+        return true;
+    }
+
+    @Override
     @Nullable
     public BucketVersioningStatus getContainerVersioning(String container) {
         try {
@@ -560,7 +565,7 @@ public final class AwsS3SdkBlobStore implements BlobStore {
             CreateMultipartUploadRequest request) {
         try {
             var response = s3Client.createMultipartUpload(request);
-            return new MultipartUpload(response.uploadId(), request);
+            return new MultipartUpload(response.uploadId(), request, response);
         } catch (S3Exception e) {
             throw propagate(e, request.bucket(), request.key());
         }

--- a/src/main/java/org/gaul/s3proxy/blobstore/BlobStore.java
+++ b/src/main/java/org/gaul/s3proxy/blobstore/BlobStore.java
@@ -263,6 +263,18 @@ public interface BlobStore extends AutoCloseable {
         throw new UnsupportedOperationException("versioning not supported");
     }
 
+    /**
+     * Whether this store forwards the requests' server-side encryption
+     * fields -- the x-amz-server-side-encryption header family on put,
+     * copy and initiate-multipart -- to a backend that performs the
+     * encryption and reports the outcome on its responses.  The frontend
+     * refuses such requests to any other store up front, rather than
+     * storing plaintext that asked to be encrypted.
+     */
+    default boolean supportsServerSideEncryption() {
+        return false;
+    }
+
     default void removeBlobs(String container, Iterable<String> names) {
         for (String name : names) {
             removeBlob(container, name);

--- a/src/main/java/org/gaul/s3proxy/blobstore/BlobStore.java
+++ b/src/main/java/org/gaul/s3proxy/blobstore/BlobStore.java
@@ -295,6 +295,18 @@ public interface BlobStore extends AutoCloseable {
     }
 
     /**
+     * Whether this store forwards the requests' server-side encryption
+     * fields -- the x-amz-server-side-encryption header family on put,
+     * copy and initiate-multipart -- to a backend that performs the
+     * encryption and reports the outcome on its responses.  The frontend
+     * refuses such requests to any other store up front, rather than
+     * storing plaintext that asked to be encrypted.
+     */
+    default boolean supportsServerSideEncryption() {
+        return false;
+    }
+
+    /**
      * Removes the objects named, reporting each one's outcome the way
      * DeleteObjects does: a Deleted entry naming any marker the delete wrote,
      * or an Error entry carrying the code the store refused it with.  A

--- a/src/main/java/org/gaul/s3proxy/blobstore/ForwardingBlobStore.java
+++ b/src/main/java/org/gaul/s3proxy/blobstore/ForwardingBlobStore.java
@@ -168,6 +168,11 @@ public abstract class ForwardingBlobStore extends ForwardingObject
     }
 
     @Override
+    public boolean supportsServerSideEncryption() {
+        return delegate().supportsServerSideEncryption();
+    }
+
+    @Override
     @Nullable
     public BucketVersioningStatus getContainerVersioning(String container) {
         return delegate().getContainerVersioning(container);

--- a/src/main/java/org/gaul/s3proxy/blobstore/ForwardingBlobStore.java
+++ b/src/main/java/org/gaul/s3proxy/blobstore/ForwardingBlobStore.java
@@ -162,6 +162,11 @@ public abstract class ForwardingBlobStore extends ForwardingObject
     }
 
     @Override
+    public boolean supportsServerSideEncryption() {
+        return delegate().supportsServerSideEncryption();
+    }
+
+    @Override
     @Nullable
     public BucketVersioningStatus getContainerVersioning(String container) {
         return delegate().getContainerVersioning(container);

--- a/src/main/java/org/gaul/s3proxy/blobstore/SdkResponses.java
+++ b/src/main/java/org/gaul/s3proxy/blobstore/SdkResponses.java
@@ -93,6 +93,7 @@ public final class SdkResponses {
     @SuppressWarnings("deprecation")
     public static HeadObjectResponse toHead(GetObjectResponse response) {
         return HeadObjectResponse.builder()
+                .bucketKeyEnabled(response.bucketKeyEnabled())
                 .cacheControl(response.cacheControl())
                 .contentDisposition(response.contentDisposition())
                 .contentEncoding(response.contentEncoding())
@@ -103,6 +104,8 @@ public final class SdkResponses {
                 .expires(response.expires())
                 .lastModified(response.lastModified())
                 .metadata(response.metadata())
+                .serverSideEncryption(response.serverSideEncryptionAsString())
+                .ssekmsKeyId(response.ssekmsKeyId())
                 .storageClass(response.storageClassAsString())
                 .versionId(response.versionId())
                 .build();

--- a/src/main/java/org/gaul/s3proxy/blobstore/SdkResponses.java
+++ b/src/main/java/org/gaul/s3proxy/blobstore/SdkResponses.java
@@ -59,7 +59,13 @@ public final class SdkResponses {
     public static GetObjectResponse toGetResponse(BlobMetadata metadata,
             @Nullable String contentRange) {
         var contentMetadata = metadata.contentMetadata();
+        var encryption = metadata.encryption();
         return GetObjectResponse.builder()
+                .serverSideEncryption(encryption == null ? null :
+                        encryption.algorithm())
+                .ssekmsKeyId(encryption == null ? null : encryption.kmsKeyId())
+                .bucketKeyEnabled(encryption == null ? null :
+                        encryption.bucketKeyEnabled())
                 .metadata(metadata.userMetadata())
                 .cacheControl(contentMetadata.cacheControl())
                 .contentDisposition(contentMetadata.contentDisposition())
@@ -93,6 +99,7 @@ public final class SdkResponses {
     @SuppressWarnings("deprecation")
     public static HeadObjectResponse toHead(GetObjectResponse response) {
         return HeadObjectResponse.builder()
+                .bucketKeyEnabled(response.bucketKeyEnabled())
                 .cacheControl(response.cacheControl())
                 .contentDisposition(response.contentDisposition())
                 .contentEncoding(response.contentEncoding())
@@ -103,6 +110,8 @@ public final class SdkResponses {
                 .expires(response.expires())
                 .lastModified(response.lastModified())
                 .metadata(response.metadata())
+                .serverSideEncryption(response.serverSideEncryptionAsString())
+                .ssekmsKeyId(response.ssekmsKeyId())
                 .storageClass(response.storageClassAsString())
                 .versionId(response.versionId())
                 .build();

--- a/src/main/java/org/gaul/s3proxy/blobstore/domain/Blob.java
+++ b/src/main/java/org/gaul/s3proxy/blobstore/domain/Blob.java
@@ -151,6 +151,11 @@ public final class Blob {
             return this;
         }
 
+        public Builder encryption(@Nullable Encryption encryption) {
+            metadataBuilder.encryption(encryption);
+            return this;
+        }
+
         public Builder userMetadata(Map<String, String> userMetadata) {
             metadataBuilder.userMetadata(userMetadata);
             return this;

--- a/src/main/java/org/gaul/s3proxy/blobstore/domain/BlobMetadata.java
+++ b/src/main/java/org/gaul/s3proxy/blobstore/domain/BlobMetadata.java
@@ -43,7 +43,8 @@ public record BlobMetadata(
         StorageClass storageClass,
         @Nullable String container,
         ContentMetadata contentMetadata,
-        @Nullable String versionId) {
+        @Nullable String versionId,
+        @Nullable Encryption encryption) {
 
     public BlobMetadata {
         userMetadata = ImmutableMap.copyOf(userMetadata);
@@ -55,7 +56,8 @@ public record BlobMetadata(
             @Nullable Date lastModified, StorageClass storageClass,
             @Nullable String container, ContentMetadata contentMetadata) {
         this(name, userMetadata, eTag, lastModified, storageClass,
-                container, contentMetadata, /*versionId=*/ null);
+                container, contentMetadata, /*versionId=*/ null,
+                /*encryption=*/ null);
     }
 
     public @Nullable Long size() {
@@ -75,7 +77,8 @@ public record BlobMetadata(
                 .storageClass(storageClass)
                 .container(container)
                 .contentMetadata(contentMetadata)
-                .versionId(versionId);
+                .versionId(versionId)
+                .encryption(encryption);
     }
 
     public static final class Builder {
@@ -88,6 +91,7 @@ public record BlobMetadata(
         private ContentMetadata contentMetadata =
                 ContentMetadata.builder().build();
         private @Nullable String versionId;
+        private @Nullable Encryption encryption;
 
         private Builder() {
         }
@@ -141,11 +145,16 @@ public record BlobMetadata(
             return this;
         }
 
+        public Builder encryption(@Nullable Encryption encryption) {
+            this.encryption = encryption;
+            return this;
+        }
+
         public BlobMetadata build() {
             return new BlobMetadata(requireNonNull(name, "name"),
                     userMetadata, eTag,
                     lastModified, storageClass, container, contentMetadata,
-                    versionId);
+                    versionId, encryption);
         }
     }
 }

--- a/src/main/java/org/gaul/s3proxy/blobstore/domain/Encryption.java
+++ b/src/main/java/org/gaul/s3proxy/blobstore/domain/Encryption.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2014-2026 Andrew Gaul <andrew@gaul.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gaul.s3proxy.blobstore.domain;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * The server-side encryption an object rests under: the algorithm, and the
+ * KMS key, context and bucket-key setting when the algorithm names one.
+ * Only a store that answers {@code supportsServerSideEncryption()} records
+ * this, and every response naming such an object reports it.
+ */
+public record Encryption(
+        String algorithm,
+        @Nullable String kmsKeyId,
+        @Nullable String kmsContext,
+        @Nullable Boolean bucketKeyEnabled) {
+
+    /** What S3 applies to an object whose write asked for nothing. */
+    public static final String DEFAULT_ALGORITHM = "AES256";
+
+    /**
+     * What a write request's encryption fields come to rest as.  A request
+     * naming no algorithm rests under the default and carries none of the
+     * KMS fields, which describe a key only the caller can have named.
+     */
+    public static Encryption forRequest(@Nullable String algorithm,
+            @Nullable String kmsKeyId, @Nullable String kmsContext,
+            @Nullable Boolean bucketKeyEnabled) {
+        return algorithm == null ?
+                new Encryption(DEFAULT_ALGORITHM, null, null, null) :
+                new Encryption(algorithm, kmsKeyId, kmsContext,
+                        bucketKeyEnabled);
+    }
+
+    /** Whether this is the default every unasked-for object rests under. */
+    public boolean isDefault() {
+        return DEFAULT_ALGORITHM.equals(algorithm) && kmsKeyId == null &&
+                kmsContext == null && bucketKeyEnabled == null;
+    }
+}

--- a/src/main/java/org/gaul/s3proxy/blobstore/domain/MultipartUpload.java
+++ b/src/main/java/org/gaul/s3proxy/blobstore/domain/MultipartUpload.java
@@ -17,16 +17,26 @@
 
 package org.gaul.s3proxy.blobstore.domain;
 
+import org.jspecify.annotations.Nullable;
+
 import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse;
 
 /**
  * One in-progress multipart upload: its id and the request that created
  * it, whose metadata stores that assemble the final object themselves
- * read back at completion.
+ * read back at completion.  A store whose backend answered the creation
+ * carries that answer too, e.g. the server-side encryption it applied;
+ * carriers reconstructed for the upload's later requests have none.
  */
 public record MultipartUpload(
         String id,
-        CreateMultipartUploadRequest request) {
+        CreateMultipartUploadRequest request,
+        @Nullable CreateMultipartUploadResponse response) {
+
+    public MultipartUpload(String id, CreateMultipartUploadRequest request) {
+        this(id, request, null);
+    }
 
     public String containerName() {
         return request.bucket();

--- a/src/main/java/org/gaul/s3proxy/nio2blob/AbstractNio2BlobStore.java
+++ b/src/main/java/org/gaul/s3proxy/nio2blob/AbstractNio2BlobStore.java
@@ -72,6 +72,7 @@ import org.gaul.s3proxy.blobstore.S3Exceptions;
 import org.gaul.s3proxy.blobstore.SdkRequests;
 import org.gaul.s3proxy.blobstore.SdkResponses;
 import org.gaul.s3proxy.blobstore.domain.Blob;
+import org.gaul.s3proxy.blobstore.domain.Encryption;
 import org.gaul.s3proxy.blobstore.domain.MultipartUpload;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -90,6 +91,7 @@ import software.amazon.awssdk.services.s3.model.CopyObjectResponse;
 import software.amazon.awssdk.services.s3.model.CopyObjectResult;
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse;
 import software.amazon.awssdk.services.s3.model.DeleteMarkerEntry;
 import software.amazon.awssdk.services.s3.model.DeleteObjectResponse;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
@@ -156,6 +158,15 @@ public abstract class AbstractNio2BlobStore implements BlobStore {
     private static final String XATTR_VERSION_KEY = "user.version-key";
     private static final String XATTR_DELETE_MARKER = "user.delete-marker";
     private static final String XATTR_VERSIONING = "user.versioning";
+    // The encryption an object rests under, written only by a store that
+    // answers supportsServerSideEncryption().  An object encrypted the way
+    // every unasked-for object is carries none of these: absent algorithm
+    // reads back as the default, so the common case costs no attribute.
+    private static final String XATTR_SSE_ALGORITHM = "user.sse-algorithm";
+    private static final String XATTR_SSE_KMS_KEY_ID = "user.sse-kms-key-id";
+    private static final String XATTR_SSE_KMS_CONTEXT = "user.sse-kms-context";
+    private static final String XATTR_SSE_BUCKET_KEY =
+            "user.sse-bucket-key-enabled";
     /** The version id every write to an unversioned container carries. */
     private static final String NULL_VERSION_ID = "null";
     private static final int UUID_STRING_LENGTH =
@@ -804,6 +815,7 @@ public abstract class AbstractNio2BlobStore implements BlobStore {
                     .storageClass(storageClass)
                     .container(container)
                     .versionId(versionId)
+                    .encryption(readEncryption(view, attributes))
                     .lastModified(lastModifiedTime);
             if (contentRange != null) {
                 builder.contentRange(contentRange);
@@ -828,14 +840,25 @@ public abstract class AbstractNio2BlobStore implements BlobStore {
     public final PutObjectResponse putBlob(PutObjectRequest request,
             InputStream payload) {
         checkNotReserved(request.key());
+        var encryption = requestEncryption(
+                request.serverSideEncryptionAsString(), request.ssekmsKeyId(),
+                request.ssekmsEncryptionContext(), request.bucketKeyEnabled());
         var result = putBlob(request.bucket(),
-                toBlobBuilder(request).payload(payload).build(),
+                toBlobBuilder(request).encryption(encryption).payload(payload)
+                        .build(),
                 SdkRequests.aclOrPrivate(request.acl()),
                 request.ifNoneMatch(),
                 /*parts=*/ null);
         return PutObjectResponse.builder()
                 .eTag(result.eTag())
                 .versionId(result.reportedVersionId())
+                .serverSideEncryption(encryption == null ? null :
+                        encryption.algorithm())
+                .ssekmsKeyId(encryption == null ? null : encryption.kmsKeyId())
+                .ssekmsEncryptionContext(encryption == null ? null :
+                        encryption.kmsContext())
+                .bucketKeyEnabled(encryption == null ? null :
+                        encryption.bucketKeyEnabled())
                 .build();
     }
 
@@ -952,6 +975,7 @@ public abstract class AbstractNio2BlobStore implements BlobStore {
                     for (var entry : blob.getMetadata().userMetadata().entrySet()) {
                         writeStringAttributeIfPresent(view, XATTR_USER_METADATA_PREFIX + entry.getKey(), entry.getValue());
                     }
+                    writeEncryptionAttr(view, blob);
                 } catch (IOException | UnsupportedOperationException e) {
                     logger.debug("xattrs not supported on {}", tmpPath);
                 }
@@ -1199,7 +1223,15 @@ public abstract class AbstractNio2BlobStore implements BlobStore {
             } else {
                 builder.userMetadata(blob.getMetadata().userMetadata());
             }
-            var result = putBlob(toContainer, builder.build(),
+            // The copy rests under what it asked for rather than under what
+            // the source rested under, the way S3 encrypts a copy: the
+            // destination is a new object, and only its own request says how.
+            var encryption = requestEncryption(
+                    request.serverSideEncryptionAsString(),
+                    request.ssekmsKeyId(), request.ssekmsEncryptionContext(),
+                    request.bucketKeyEnabled());
+            var result = putBlob(toContainer,
+                    builder.encryption(encryption).build(),
                     SdkRequests.aclOrPrivate(request.acl()),
                     /*ifNoneMatch=*/ null,
                     /*parts=*/ null);
@@ -1210,6 +1242,14 @@ public abstract class AbstractNio2BlobStore implements BlobStore {
                     .versionId(result.reportedVersionId())
                     .copySourceVersionId(NULL_VERSION_ID.equals(
                             sourceVersionId) ? null : sourceVersionId)
+                    .serverSideEncryption(encryption == null ? null :
+                            encryption.algorithm())
+                    .ssekmsKeyId(encryption == null ? null :
+                            encryption.kmsKeyId())
+                    .ssekmsEncryptionContext(encryption == null ? null :
+                            encryption.kmsContext())
+                    .bucketKeyEnabled(encryption == null ? null :
+                            encryption.bucketKeyEnabled())
                     .build();
         } catch (IOException ioe) {
             throw new RuntimeException(ioe);
@@ -1834,11 +1874,48 @@ public abstract class AbstractNio2BlobStore implements BlobStore {
         // which is the same write putBlob refuses above.
         checkNotReserved(request.key());
         var uploadId = UUID.randomUUID().toString();
+        // The carriers built for this upload's later requests name only the
+        // bucket and key, so the encryption it was created under has to
+        // outlive the create; the stub is where the upload keeps it.
+        var encryption = requestEncryption(
+                request.serverSideEncryptionAsString(), request.ssekmsKeyId(),
+                request.ssekmsEncryptionContext(), request.bucketKeyEnabled());
         // create a stub blob
-        var blob = Blob.builder(MULTIPART_PREFIX + uploadId + "-" + request.key() + "-stub").payload(ByteSource.empty()).build();
+        var blob = Blob.builder(MULTIPART_PREFIX + uploadId + "-" + request.key() + "-stub").payload(ByteSource.empty()).encryption(encryption).build();
         putBlob(request.bucket(), blob, ObjectCannedACL.PRIVATE,
                 /*ifNoneMatch=*/ null, /*parts=*/ null);
-        return new MultipartUpload(uploadId, request);
+        return new MultipartUpload(uploadId, request,
+                encryption == null ? null :
+                        CreateMultipartUploadResponse.builder()
+                                .bucket(request.bucket())
+                                .key(request.key())
+                                .uploadId(uploadId)
+                                .serverSideEncryption(encryption.algorithm())
+                                .ssekmsKeyId(encryption.kmsKeyId())
+                                .ssekmsEncryptionContext(
+                                        encryption.kmsContext())
+                                .bucketKeyEnabled(encryption.bucketKeyEnabled())
+                                .build());
+    }
+
+    /** The encryption an upload was created under, kept on its stub. */
+    @Nullable
+    private Encryption uploadEncryption(MultipartUpload mpu) {
+        if (!supportsServerSideEncryption()) {
+            return null;
+        }
+        // The domain metadata rather than a HEAD response, which has no
+        // field for the KMS context the upload may have named.
+        String stubName = MULTIPART_PREFIX + mpu.id() + "-" +
+                mpu.blobName() + "-stub";
+        var stub = getBlobInternal(mpu.containerName(), stubName,
+                GetObjectRequest.builder()
+                        .bucket(mpu.containerName())
+                        .key(stubName)
+                        .build(),
+                /*openStream=*/ false);
+        return stub == null ? Encryption.forRequest(null, null, null, null) :
+                stub.getMetadata().encryption();
     }
 
     @Override
@@ -1916,6 +1993,11 @@ public abstract class AbstractNio2BlobStore implements BlobStore {
         if (storageClass != null) {
             blobBuilder.storageClass(storageClass);
         }
+        // The assembled object rests under what the upload was created
+        // under, which the stub has carried since; this request's carrier
+        // names only the bucket and key.
+        var encryption = uploadEncryption(mpu);
+        blobBuilder.encryption(encryption);
 
         // Publishing the assembled object is the write the condition applies
         // to, so hand it to putBlob rather than checking it beforehand.  A
@@ -1951,6 +2033,11 @@ public abstract class AbstractNio2BlobStore implements BlobStore {
         return CompleteMultipartUploadResponse.builder()
                 .eTag(mpuETag)
                 .versionId(result.reportedVersionId())
+                .serverSideEncryption(encryption == null ? null :
+                        encryption.algorithm())
+                .ssekmsKeyId(encryption == null ? null : encryption.kmsKeyId())
+                .bucketKeyEnabled(encryption == null ? null :
+                        encryption.bucketKeyEnabled())
                 .build();
     }
 
@@ -1965,7 +2052,16 @@ public abstract class AbstractNio2BlobStore implements BlobStore {
         var partETag = putBlob(mpu.containerName(), blob,
                 ObjectCannedACL.PRIVATE, /*ifNoneMatch=*/ null, /*parts=*/ null)
                 .eTag();
-        return SdkResponses.uploadedPart(partETag);
+        var encryption = uploadEncryption(mpu);
+        if (encryption == null) {
+            return SdkResponses.uploadedPart(partETag);
+        }
+        return UploadPartResponse.builder()
+                .eTag(partETag)
+                .serverSideEncryption(encryption.algorithm())
+                .ssekmsKeyId(encryption.kmsKeyId())
+                .bucketKeyEnabled(encryption.bucketKeyEnabled())
+                .build();
     }
 
     @Override
@@ -2241,6 +2337,70 @@ public abstract class AbstractNio2BlobStore implements BlobStore {
         }
     }
 
+    /**
+     * What a write request's encryption fields come to rest as, or null
+     * where this store does not encrypt -- there the frontend has refused
+     * anything naming them, so the request carries none to record.
+     */
+    @Nullable
+    private Encryption requestEncryption(@Nullable String algorithm,
+            @Nullable String kmsKeyId, @Nullable String kmsContext,
+            @Nullable Boolean bucketKeyEnabled) {
+        return supportsServerSideEncryption() ? Encryption.forRequest(
+                algorithm, kmsKeyId, kmsContext, bucketKeyEnabled) : null;
+    }
+
+    /**
+     * The encryption an object rests under, or null where the store does not
+     * encrypt -- there the frontend has already refused every request naming
+     * any of it, so reporting one would answer a question nobody asked.  An
+     * object written without an algorithm attribute rests under the default,
+     * the way S3 encrypts what nobody asked it to.
+     */
+    @Nullable
+    private Encryption readEncryption(
+            @Nullable UserDefinedFileAttributeView view,
+            Set<String> attributes) throws IOException {
+        if (!supportsServerSideEncryption()) {
+            return null;
+        }
+        if (view == null) {
+            return Encryption.forRequest(null, null, null, null);
+        }
+        var bucketKey = readStringAttributeIfPresent(view, attributes,
+                XATTR_SSE_BUCKET_KEY);
+        var algorithm = readStringAttributeIfPresent(view, attributes,
+                XATTR_SSE_ALGORITHM);
+        return new Encryption(
+                algorithm == null ? Encryption.DEFAULT_ALGORITHM : algorithm,
+                readStringAttributeIfPresent(view, attributes,
+                        XATTR_SSE_KMS_KEY_ID),
+                readStringAttributeIfPresent(view, attributes,
+                        XATTR_SSE_KMS_CONTEXT),
+                bucketKey == null ? null : Boolean.valueOf(bucketKey));
+    }
+
+    /**
+     * Records an object's encryption, writing nothing for the default that
+     * an absent algorithm already reads back as.
+     */
+    private static void writeEncryptionAttr(
+            UserDefinedFileAttributeView view, Blob blob) throws IOException {
+        var encryption = blob.getMetadata().encryption();
+        if (encryption == null || encryption.isDefault()) {
+            return;
+        }
+        writeStringAttributeIfPresent(view, XATTR_SSE_ALGORITHM,
+                encryption.algorithm());
+        writeStringAttributeIfPresent(view, XATTR_SSE_KMS_KEY_ID,
+                encryption.kmsKeyId());
+        writeStringAttributeIfPresent(view, XATTR_SSE_KMS_CONTEXT,
+                encryption.kmsContext());
+        writeStringAttributeIfPresent(view, XATTR_SSE_BUCKET_KEY,
+                encryption.bucketKeyEnabled() == null ? null :
+                        encryption.bucketKeyEnabled().toString());
+    }
+
     // TODO: call in other places
     private static void writeCommonMetadataAttr(UserDefinedFileAttributeView view, Blob blob) throws IOException {
         var metadata = blob.getMetadata().contentMetadata();
@@ -2259,6 +2419,7 @@ public abstract class AbstractNio2BlobStore implements BlobStore {
         for (var entry : blob.getMetadata().userMetadata().entrySet()) {
             writeStringAttributeIfPresent(view, XATTR_USER_METADATA_PREFIX + entry.getKey(), entry.getValue());
         }
+        writeEncryptionAttr(view, blob);
     }
 
     private record XattrState(@Nullable UserDefinedFileAttributeView view,

--- a/src/main/java/org/gaul/s3proxy/nio2blob/TransientNio2BlobStore.java
+++ b/src/main/java/org/gaul/s3proxy/nio2blob/TransientNio2BlobStore.java
@@ -50,4 +50,20 @@ public final class TransientNio2BlobStore extends AbstractNio2BlobStore {
     public boolean supportsVersioning() {
         return true;
     }
+
+    /**
+     * Server-side encryption is answered here and refused by the filesystem
+     * store, on the same line versioning is drawn.  What this store holds
+     * never rests anywhere a caller could read it: the filesystem it keeps
+     * objects in lives and dies with the process, so an object's encryption
+     * is the header family and nothing else, which is all S3 lets a caller
+     * observe of SSE-S3 anyway.  Bytes written to a real disk are another
+     * matter -- reporting AES256 over plaintext a caller could go and read
+     * would be a claim S3Proxy has no business making -- so the filesystem
+     * store answers those requests NotImplemented instead.
+     */
+    @Override
+    public boolean supportsServerSideEncryption() {
+        return true;
+    }
 }

--- a/src/test/java/org/gaul/s3proxy/InMemorySseBlobStore.java
+++ b/src/test/java/org/gaul/s3proxy/InMemorySseBlobStore.java
@@ -1,0 +1,406 @@
+/*
+ * Copyright 2014-2026 Andrew Gaul <andrew@gaul.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gaul.s3proxy;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.google.common.hash.HashCode;
+import com.google.common.hash.Hashing;
+
+import org.gaul.s3proxy.blobstore.BlobStore;
+import org.gaul.s3proxy.blobstore.S3Exceptions;
+import org.gaul.s3proxy.blobstore.SdkResponses;
+import org.gaul.s3proxy.blobstore.domain.MultipartUpload;
+import org.jspecify.annotations.Nullable;
+
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.services.s3.model.BucketCannedACL;
+import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse;
+import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
+import software.amazon.awssdk.services.s3.model.CopyObjectResponse;
+import software.amazon.awssdk.services.s3.model.CopyObjectResult;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.ListBucketsResponse;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.NoSuchUploadException;
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
+import software.amazon.awssdk.services.s3.model.Part;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.model.UploadPartResponse;
+
+/**
+ * A minimal in-memory BlobStore treating server-side encryption the way S3
+ * does -- applies AES256 when a request names nothing, honors whatever it
+ * names, and reports the outcome on every response -- standing in for the
+ * aws-s3-sdk backend so the frontend's forwarding and reporting can be
+ * exercised end to end without one.  The write requests seen are kept for
+ * asserting what was forwarded.  Only the paths the encryption tests walk
+ * are implemented.
+ */
+final class InMemorySseBlobStore implements BlobStore {
+    private final SortedMap<String, SortedMap<String, StoredBlob>> containers =
+            new TreeMap<>();
+    private final SortedMap<String, Upload> uploads = new TreeMap<>();
+    private final AtomicLong uploadCounter = new AtomicLong();
+    private @Nullable PutObjectRequest lastPutRequest;
+    private @Nullable CopyObjectRequest lastCopyRequest;
+    private @Nullable CreateMultipartUploadRequest lastCreateRequest;
+
+    /** The encryption an object rests under, as S3 would report it. */
+    private record Encryption(String algorithm, @Nullable String kmsKeyId,
+            @Nullable String kmsContext, @Nullable Boolean bucketKeyEnabled) {
+        /** What a write request's fields come to rest as: the S3 default
+         * when it names nothing. */
+        static Encryption forRequest(@Nullable String algorithm,
+                @Nullable String kmsKeyId, @Nullable String kmsContext,
+                @Nullable Boolean bucketKeyEnabled) {
+            return algorithm == null ?
+                    new Encryption("AES256", null, null, null) :
+                    new Encryption(algorithm, kmsKeyId, kmsContext,
+                            bucketKeyEnabled);
+        }
+    }
+
+    @SuppressWarnings("ArrayRecordComponent")
+    private record StoredBlob(byte[] content, String eTag,
+            Instant lastModified, Encryption encryption) {
+    }
+
+    @SuppressWarnings("ArrayRecordComponent")
+    private record StoredPart(byte[] content, String eTag) {
+    }
+
+    private record Upload(CreateMultipartUploadRequest request,
+            Encryption encryption, SortedMap<Integer, StoredPart> parts) {
+    }
+
+    synchronized @Nullable PutObjectRequest lastPutRequest() {
+        return lastPutRequest;
+    }
+
+    synchronized @Nullable CopyObjectRequest lastCopyRequest() {
+        return lastCopyRequest;
+    }
+
+    synchronized @Nullable CreateMultipartUploadRequest lastCreateRequest() {
+        return lastCreateRequest;
+    }
+
+    private SortedMap<String, StoredBlob> getContainer(String containerName) {
+        var container = containers.get(containerName);
+        if (container == null) {
+            throw S3Exceptions.noSuchBucket(containerName, "");
+        }
+        return container;
+    }
+
+    private Upload getUpload(String id) {
+        var upload = uploads.get(id);
+        if (upload == null) {
+            throw NoSuchUploadException.builder()
+                    .message("no such upload " + id)
+                    .statusCode(404)
+                    .build();
+        }
+        return upload;
+    }
+
+    @SuppressWarnings("deprecation")
+    private static String eTagOf(byte[] content) {
+        return Hashing.md5().hashBytes(content).toString();
+    }
+
+    @Override
+    public ListBucketsResponse list() {
+        throw new UnsupportedOperationException("listing not supported");
+    }
+
+    @Override
+    public ListObjectsV2Response list(ListObjectsV2Request request) {
+        throw new UnsupportedOperationException("listing not supported");
+    }
+
+    @Override
+    public synchronized boolean containerExists(String containerName) {
+        return containers.containsKey(containerName);
+    }
+
+    @Override
+    public synchronized boolean createContainer(CreateBucketRequest request) {
+        return containers.putIfAbsent(request.bucket(),
+                new TreeMap<>()) == null;
+    }
+
+    @Override
+    public BucketCannedACL getContainerAccess(String containerName) {
+        return BucketCannedACL.PRIVATE;
+    }
+
+    @Override
+    public void setContainerAccess(String containerName,
+            BucketCannedACL access) {
+    }
+
+    @Override
+    public synchronized boolean deleteContainerIfEmpty(String containerName) {
+        var container = getContainer(containerName);
+        if (!container.isEmpty()) {
+            return false;
+        }
+        containers.remove(containerName);
+        return true;
+    }
+
+    @Override
+    public synchronized boolean blobExists(String containerName, String key) {
+        return getContainer(containerName).containsKey(key);
+    }
+
+    /**
+     * True so that completeMultipartUpload runs synchronously, as it does
+     * on the aws-s3 store, whose completion response carries the
+     * encryption headers this store exists to exercise.
+     */
+    @Override
+    public boolean supportsVersioning() {
+        return true;
+    }
+
+    @Override
+    public boolean supportsServerSideEncryption() {
+        return true;
+    }
+
+    @Override
+    public synchronized PutObjectResponse putBlob(PutObjectRequest request,
+            InputStream payload) {
+        lastPutRequest = request;
+        var container = getContainer(request.bucket());
+        byte[] content = readPayload(payload);
+        var encryption = Encryption.forRequest(
+                request.serverSideEncryptionAsString(), request.ssekmsKeyId(),
+                request.ssekmsEncryptionContext(), request.bucketKeyEnabled());
+        var blob = new StoredBlob(content, eTagOf(content), Instant.now(),
+                encryption);
+        container.put(request.key(), blob);
+        return PutObjectResponse.builder()
+                .eTag(blob.eTag())
+                .serverSideEncryption(encryption.algorithm())
+                .ssekmsKeyId(encryption.kmsKeyId())
+                .ssekmsEncryptionContext(encryption.kmsContext())
+                .bucketKeyEnabled(encryption.bucketKeyEnabled())
+                .build();
+    }
+
+    @Override
+    public synchronized CopyObjectResponse copyBlob(CopyObjectRequest request) {
+        lastCopyRequest = request;
+        var source = getContainer(request.sourceBucket())
+                .get(request.sourceKey());
+        if (source == null) {
+            throw S3Exceptions.noSuchKey(request.sourceBucket(),
+                    request.sourceKey(), "while copying");
+        }
+        var encryption = Encryption.forRequest(
+                request.serverSideEncryptionAsString(), request.ssekmsKeyId(),
+                request.ssekmsEncryptionContext(), request.bucketKeyEnabled());
+        var dest = new StoredBlob(source.content(), source.eTag(),
+                Instant.now(), encryption);
+        getContainer(request.destinationBucket())
+                .put(request.destinationKey(), dest);
+        return CopyObjectResponse.builder()
+                .copyObjectResult(CopyObjectResult.builder()
+                        .eTag(dest.eTag())
+                        .lastModified(dest.lastModified())
+                        .build())
+                .serverSideEncryption(encryption.algorithm())
+                .ssekmsKeyId(encryption.kmsKeyId())
+                .ssekmsEncryptionContext(encryption.kmsContext())
+                .bucketKeyEnabled(encryption.bucketKeyEnabled())
+                .build();
+    }
+
+    @Override
+    @Nullable
+    public synchronized HeadObjectResponse blobMetadata(
+            HeadObjectRequest request) {
+        var blob = getContainer(request.bucket()).get(request.key());
+        if (blob == null) {
+            return null;
+        }
+        return HeadObjectResponse.builder()
+                .eTag(blob.eTag())
+                .contentLength((long) blob.content().length)
+                .lastModified(blob.lastModified())
+                .serverSideEncryption(blob.encryption().algorithm())
+                .ssekmsKeyId(blob.encryption().kmsKeyId())
+                .bucketKeyEnabled(blob.encryption().bucketKeyEnabled())
+                .build();
+    }
+
+    @Override
+    @Nullable
+    public synchronized ResponseInputStream<GetObjectResponse> getBlob(
+            GetObjectRequest request) {
+        var blob = getContainer(request.bucket()).get(request.key());
+        if (blob == null) {
+            return null;
+        }
+        return SdkResponses.getResponse(GetObjectResponse.builder()
+                        .eTag(blob.eTag())
+                        .contentLength((long) blob.content().length)
+                        .lastModified(blob.lastModified())
+                        .serverSideEncryption(blob.encryption().algorithm())
+                        .ssekmsKeyId(blob.encryption().kmsKeyId())
+                        .bucketKeyEnabled(blob.encryption().bucketKeyEnabled())
+                        .build(),
+                new ByteArrayInputStream(blob.content()));
+    }
+
+    @Override
+    public synchronized void removeBlob(String containerName, String key) {
+        getContainer(containerName).remove(key);
+    }
+
+    @Override
+    public ObjectCannedACL getBlobAccess(String containerName, String key) {
+        return ObjectCannedACL.PRIVATE;
+    }
+
+    @Override
+    public void setBlobAccess(String containerName, String key,
+            ObjectCannedACL access) {
+    }
+
+    @Override
+    public synchronized MultipartUpload initiateMultipartUpload(
+            CreateMultipartUploadRequest request) {
+        lastCreateRequest = request;
+        getContainer(request.bucket());
+        var encryption = Encryption.forRequest(
+                request.serverSideEncryptionAsString(), request.ssekmsKeyId(),
+                request.ssekmsEncryptionContext(), request.bucketKeyEnabled());
+        String id = "upload-" + uploadCounter.incrementAndGet();
+        uploads.put(id, new Upload(request, encryption, new TreeMap<>()));
+        return new MultipartUpload(id, request,
+                CreateMultipartUploadResponse.builder()
+                        .bucket(request.bucket())
+                        .key(request.key())
+                        .uploadId(id)
+                        .serverSideEncryption(encryption.algorithm())
+                        .ssekmsKeyId(encryption.kmsKeyId())
+                        .ssekmsEncryptionContext(encryption.kmsContext())
+                        .bucketKeyEnabled(encryption.bucketKeyEnabled())
+                        .build());
+    }
+
+    @Override
+    public synchronized void abortMultipartUpload(MultipartUpload mpu) {
+        uploads.remove(mpu.id());
+    }
+
+    @Override
+    public synchronized CompleteMultipartUploadResponse
+            completeMultipartUpload(MultipartUpload mpu,
+                    CompleteMultipartUploadRequest request) {
+        var upload = getUpload(mpu.id());
+        var out = new ByteArrayOutputStream();
+        for (var part : upload.parts().values()) {
+            out.writeBytes(part.content());
+        }
+        byte[] content = out.toByteArray();
+        var blob = new StoredBlob(content, eTagOf(content), Instant.now(),
+                upload.encryption());
+        getContainer(upload.request().bucket())
+                .put(upload.request().key(), blob);
+        uploads.remove(mpu.id());
+        return CompleteMultipartUploadResponse.builder()
+                .bucket(upload.request().bucket())
+                .key(upload.request().key())
+                .eTag(blob.eTag())
+                .serverSideEncryption(upload.encryption().algorithm())
+                .ssekmsKeyId(upload.encryption().kmsKeyId())
+                .bucketKeyEnabled(upload.encryption().bucketKeyEnabled())
+                .build();
+    }
+
+    @Override
+    public synchronized UploadPartResponse uploadMultipartPart(
+            MultipartUpload mpu, int partNumber, InputStream is,
+            long contentLength, @Nullable HashCode contentMD5) {
+        var upload = getUpload(mpu.id());
+        byte[] content = readPayload(is);
+        var part = new StoredPart(content, eTagOf(content));
+        upload.parts().put(partNumber, part);
+        return UploadPartResponse.builder()
+                .eTag(part.eTag())
+                .serverSideEncryption(upload.encryption().algorithm())
+                .ssekmsKeyId(upload.encryption().kmsKeyId())
+                .bucketKeyEnabled(upload.encryption().bucketKeyEnabled())
+                .build();
+    }
+
+    @Override
+    public synchronized List<Part> listMultipartUpload(MultipartUpload mpu) {
+        var upload = getUpload(mpu.id());
+        var parts = new ArrayList<Part>();
+        for (var entry : upload.parts().entrySet()) {
+            parts.add(SdkResponses.part(entry.getKey(),
+                    (long) entry.getValue().content().length,
+                    entry.getValue().eTag(), new Date()));
+        }
+        return parts;
+    }
+
+    @Override
+    public List<software.amazon.awssdk.services.s3.model.MultipartUpload>
+            listMultipartUploads(String containerName) {
+        throw new UnsupportedOperationException("listing not supported");
+    }
+
+    @Override
+    public long getMinimumMultipartPartSize() {
+        return 1;
+    }
+
+    private static byte[] readPayload(InputStream payload) {
+        try (var is = payload) {
+            return is.readAllBytes();
+        } catch (IOException ioe) {
+            throw new RuntimeException(ioe);
+        }
+    }
+}

--- a/src/test/java/org/gaul/s3proxy/ReadOnlyBlobStoreTest.java
+++ b/src/test/java/org/gaul/s3proxy/ReadOnlyBlobStoreTest.java
@@ -148,7 +148,7 @@ public final class ReadOnlyBlobStoreTest {
                 "getContainerVersioning", "getMinimumMultipartPartSize",
                 "list", "listMultipartUpload", "listMultipartUploads",
                 "listV1", "listVersions", "supportsCopyMultipartPart",
-                "supportsVersioning");
+                "supportsServerSideEncryption", "supportsVersioning");
 
         var missing = new ArrayList<String>();
         for (Method method : ForwardingBlobStore.class.getDeclaredMethods()) {

--- a/src/test/java/org/gaul/s3proxy/ServerSideEncryptionTest.java
+++ b/src/test/java/org/gaul/s3proxy/ServerSideEncryptionTest.java
@@ -1,0 +1,297 @@
+/*
+ * Copyright 2014-2026 Andrew Gaul <andrew@gaul.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gaul.s3proxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import com.google.common.hash.Hashing;
+
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.gaul.s3proxy.blobstore.BlobStore;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.model.CompletedMultipartUpload;
+import software.amazon.awssdk.services.s3.model.CompletedPart;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.model.ServerSideEncryption;
+
+/**
+ * Exercises server-side encryption as a pass-through: the frontend
+ * forwards the request's encryption verbatim to a store that supports it
+ * and reports on every response what the backend answered -- not what was
+ * asked -- and refuses the request family up front everywhere else.
+ */
+public final class ServerSideEncryptionTest {
+    private static final String KMS_KEY_ID =
+            "arn:aws:kms:us-east-1:123456789012:key/test-key";
+    private static final String KMS_CONTEXT = Base64.getEncoder()
+            .encodeToString("{\"purpose\":\"testing\"}"
+                    .getBytes(StandardCharsets.UTF_8));
+
+    private S3Proxy s3Proxy;
+    private S3Client client;
+    private String containerName;
+
+    private void start(BlobStore blobStore) throws Exception {
+        containerName = TestUtils.createRandomContainerName();
+
+        s3Proxy = S3Proxy.builder()
+                .stopTimeout(0)
+                .endpoint(URI.create("http://127.0.0.1:0"))
+                .blobStore(blobStore)
+                .build();
+        s3Proxy.start();
+
+        client = S3Client.builder()
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create("identity", "credential")))
+                .region(Region.US_EAST_1)
+                .endpointOverride(URI.create(
+                        "http://127.0.0.1:" + s3Proxy.getPort()))
+                .serviceConfiguration(S3Configuration.builder()
+                        .pathStyleAccessEnabled(true)
+                        .build())
+                .build();
+
+        client.createBucket(b -> b.bucket(containerName));
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        if (client != null) {
+            client.close();
+        }
+        if (s3Proxy != null) {
+            s3Proxy.stop();
+        }
+    }
+
+    @Test
+    public void testReportsBackendDefaultEncryption() throws Exception {
+        var blobStore = new InMemorySseBlobStore();
+        start(blobStore);
+
+        // ask for nothing: what comes back is the backend's own default,
+        // proving the report derives from the backend's answer
+        var put = client.putObject(b -> b.bucket(containerName).key("blob"),
+                RequestBody.fromString("payload"));
+        assertThat(blobStore.lastPutRequest().serverSideEncryption()).isNull();
+        assertThat(put.serverSideEncryption())
+                .isEqualTo(ServerSideEncryption.AES256);
+
+        var head = client.headObject(b -> b.bucket(containerName).key("blob"));
+        assertThat(head.serverSideEncryption())
+                .isEqualTo(ServerSideEncryption.AES256);
+
+        var get = client.getObjectAsBytes(
+                b -> b.bucket(containerName).key("blob"));
+        assertThat(get.response().serverSideEncryption())
+                .isEqualTo(ServerSideEncryption.AES256);
+        assertThat(get.asUtf8String()).isEqualTo("payload");
+    }
+
+    @Test
+    public void testPutForwardsRequestedEncryption() throws Exception {
+        var blobStore = new InMemorySseBlobStore();
+        start(blobStore);
+
+        var put = client.putObject(b -> b.bucket(containerName).key("blob")
+                        .serverSideEncryption(ServerSideEncryption.AWS_KMS)
+                        .ssekmsKeyId(KMS_KEY_ID)
+                        .ssekmsEncryptionContext(KMS_CONTEXT)
+                        .bucketKeyEnabled(true),
+                RequestBody.fromString("payload"));
+
+        var forwarded = blobStore.lastPutRequest();
+        assertThat(forwarded.serverSideEncryption())
+                .isEqualTo(ServerSideEncryption.AWS_KMS);
+        assertThat(forwarded.ssekmsKeyId()).isEqualTo(KMS_KEY_ID);
+        assertThat(forwarded.ssekmsEncryptionContext()).isEqualTo(KMS_CONTEXT);
+        assertThat(forwarded.bucketKeyEnabled()).isTrue();
+
+        assertThat(put.serverSideEncryption())
+                .isEqualTo(ServerSideEncryption.AWS_KMS);
+        assertThat(put.ssekmsKeyId()).isEqualTo(KMS_KEY_ID);
+        assertThat(put.ssekmsEncryptionContext()).isEqualTo(KMS_CONTEXT);
+        assertThat(put.bucketKeyEnabled()).isTrue();
+
+        var head = client.headObject(b -> b.bucket(containerName).key("blob"));
+        assertThat(head.serverSideEncryption())
+                .isEqualTo(ServerSideEncryption.AWS_KMS);
+        assertThat(head.ssekmsKeyId()).isEqualTo(KMS_KEY_ID);
+        assertThat(head.bucketKeyEnabled()).isTrue();
+    }
+
+    @Test
+    public void testCopyForwardsRequestedEncryption() throws Exception {
+        var blobStore = new InMemorySseBlobStore();
+        start(blobStore);
+        client.putObject(b -> b.bucket(containerName).key("blob"),
+                RequestBody.fromString("payload"));
+
+        var copy = client.copyObject(b -> b
+                .sourceBucket(containerName).sourceKey("blob")
+                .destinationBucket(containerName).destinationKey("copy")
+                .serverSideEncryption(ServerSideEncryption.AWS_KMS)
+                .ssekmsKeyId(KMS_KEY_ID));
+
+        var forwarded = blobStore.lastCopyRequest();
+        assertThat(forwarded.serverSideEncryption())
+                .isEqualTo(ServerSideEncryption.AWS_KMS);
+        assertThat(forwarded.ssekmsKeyId()).isEqualTo(KMS_KEY_ID);
+
+        assertThat(copy.serverSideEncryption())
+                .isEqualTo(ServerSideEncryption.AWS_KMS);
+        assertThat(copy.ssekmsKeyId()).isEqualTo(KMS_KEY_ID);
+
+        var head = client.headObject(b -> b.bucket(containerName).key("copy"));
+        assertThat(head.serverSideEncryption())
+                .isEqualTo(ServerSideEncryption.AWS_KMS);
+        assertThat(head.ssekmsKeyId()).isEqualTo(KMS_KEY_ID);
+    }
+
+    @Test
+    public void testMultipartReportsEncryption() throws Exception {
+        var blobStore = new InMemorySseBlobStore();
+        start(blobStore);
+
+        var create = client.createMultipartUpload(
+                b -> b.bucket(containerName).key("mpu")
+                        .serverSideEncryption(ServerSideEncryption.AWS_KMS)
+                        .ssekmsKeyId(KMS_KEY_ID));
+        assertThat(blobStore.lastCreateRequest().serverSideEncryption())
+                .isEqualTo(ServerSideEncryption.AWS_KMS);
+        assertThat(create.serverSideEncryption())
+                .isEqualTo(ServerSideEncryption.AWS_KMS);
+        assertThat(create.ssekmsKeyId()).isEqualTo(KMS_KEY_ID);
+
+        var part = client.uploadPart(
+                b -> b.bucket(containerName).key("mpu")
+                        .uploadId(create.uploadId()).partNumber(1),
+                RequestBody.fromString("payload"));
+        assertThat(part.serverSideEncryption())
+                .isEqualTo(ServerSideEncryption.AWS_KMS);
+
+        var complete = client.completeMultipartUpload(
+                b -> b.bucket(containerName).key("mpu")
+                        .uploadId(create.uploadId())
+                        .multipartUpload(CompletedMultipartUpload.builder()
+                                .parts(CompletedPart.builder()
+                                        .partNumber(1)
+                                        .eTag(part.eTag())
+                                        .build())
+                                .build()));
+        assertThat(complete.serverSideEncryption())
+                .isEqualTo(ServerSideEncryption.AWS_KMS);
+        assertThat(complete.ssekmsKeyId()).isEqualTo(KMS_KEY_ID);
+
+        var head = client.headObject(b -> b.bucket(containerName).key("mpu"));
+        assertThat(head.serverSideEncryption())
+                .isEqualTo(ServerSideEncryption.AWS_KMS);
+        assertThat(head.ssekmsKeyId()).isEqualTo(KMS_KEY_ID);
+    }
+
+    @Test
+    public void testRefusesWhereBackendCannotEncrypt() throws Exception {
+        start(TestUtils.createTransientBlobStore());
+
+        // without the header everything still works
+        client.putObject(b -> b.bucket(containerName).key("blob"),
+                RequestBody.fromString("payload"));
+
+        assertRefused(() -> client.putObject(
+                b -> b.bucket(containerName).key("blob")
+                        .serverSideEncryption(ServerSideEncryption.AES256),
+                RequestBody.fromString("payload")));
+        assertRefused(() -> client.putObject(
+                b -> b.bucket(containerName).key("blob")
+                        .serverSideEncryption(ServerSideEncryption.AWS_KMS)
+                        .ssekmsKeyId(KMS_KEY_ID),
+                RequestBody.fromString("payload")));
+        assertRefused(() -> client.copyObject(b -> b
+                .sourceBucket(containerName).sourceKey("blob")
+                .destinationBucket(containerName).destinationKey("copy")
+                .serverSideEncryption(ServerSideEncryption.AES256)));
+        assertRefused(() -> client.createMultipartUpload(
+                b -> b.bucket(containerName).key("mpu")
+                        .serverSideEncryption(ServerSideEncryption.AES256)));
+    }
+
+    @Test
+    public void testRefusesReadCarryingEncryptionHeader() throws Exception {
+        start(TestUtils.createTransientBlobStore());
+        client.putObject(b -> b.bucket(containerName).key("blob"),
+                RequestBody.fromString("payload"));
+
+        // The header is refused on every method a store that cannot
+        // encrypt sees, as before it was understood at all.
+        var uri = URI.create("http://127.0.0.1:" + s3Proxy.getPort() + "/" +
+                containerName + "/blob");
+        var response = HttpClient.newHttpClient().send(
+                HttpRequest.newBuilder(uri)
+                        .header("x-amz-server-side-encryption", "AES256")
+                        .GET()
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+        assertThat(response.statusCode()).isEqualTo(501);
+
+        response = HttpClient.newHttpClient().send(
+                HttpRequest.newBuilder(uri).GET().build(),
+                HttpResponse.BodyHandlers.ofString());
+        assertThat(response.statusCode()).isEqualTo(200);
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testCustomerKeysStayRefused() throws Exception {
+        // SSE-C stays out even on a store that forwards SSE: dropping the
+        // caller's key would claim an encryption nobody performed.
+        start(new InMemorySseBlobStore());
+
+        byte[] key = "0123456789abcdef0123456789abcdef"
+                .getBytes(StandardCharsets.UTF_8);
+        assertRefused(() -> client.putObject(
+                b -> b.bucket(containerName).key("blob")
+                        .sseCustomerAlgorithm("AES256")
+                        .sseCustomerKey(Base64.getEncoder()
+                                .encodeToString(key))
+                        .sseCustomerKeyMD5(Base64.getEncoder().encodeToString(
+                                Hashing.md5().hashBytes(key).asBytes())),
+                RequestBody.fromString("payload")));
+    }
+
+    private static void assertRefused(ThrowingCallable callable) {
+        assertThatThrownBy(callable)
+                .isInstanceOfSatisfying(S3Exception.class,
+                        e -> assertThat(e.statusCode()).isEqualTo(501));
+    }
+}

--- a/src/test/java/org/gaul/s3proxy/ServerSideEncryptionTest.java
+++ b/src/test/java/org/gaul/s3proxy/ServerSideEncryptionTest.java
@@ -1,0 +1,350 @@
+/*
+ * Copyright 2014-2026 Andrew Gaul <andrew@gaul.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gaul.s3proxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Base64;
+
+import com.google.common.hash.Hashing;
+
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.gaul.s3proxy.blobstore.BlobStore;
+import org.gaul.s3proxy.nio2blob.FilesystemNio2BlobStore;
+import org.gaul.s3proxy.nio2blob.TransientNio2BlobStore;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.model.CompletedMultipartUpload;
+import software.amazon.awssdk.services.s3.model.CompletedPart;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.model.ServerSideEncryption;
+
+/**
+ * Server-side encryption end to end over the two nio2 stores, which share
+ * the implementation and differ in whether they own up to it.  The transient
+ * store answers the header family: what it holds never rests anywhere a
+ * caller could read it, so an object's encryption is the family and nothing
+ * else, which is all S3 lets a caller observe of SSE-S3 anyway.  The
+ * filesystem store writes to a real disk, where reporting AES256 over
+ * readable plaintext would be a claim S3Proxy has no business making, so it
+ * refuses the family on every method -- as both stores did before these
+ * headers were understood at all.
+ */
+public final class ServerSideEncryptionTest {
+    private static final String KMS_KEY_ID =
+            "arn:aws:kms:us-east-1:123456789012:key/test-key";
+    private static final String KMS_CONTEXT = Base64.getEncoder()
+            .encodeToString("{\"purpose\":\"testing\"}"
+                    .getBytes(StandardCharsets.UTF_8));
+
+    @TempDir
+    private Path root;
+    private S3Proxy s3Proxy;
+    private S3Client client;
+    private String containerName;
+
+    private void start(BlobStore blobStore) throws Exception {
+        containerName = TestUtils.createRandomContainerName();
+
+        s3Proxy = S3Proxy.builder()
+                .stopTimeout(0)
+                .endpoint(URI.create("http://127.0.0.1:0"))
+                .blobStore(blobStore)
+                .build();
+        s3Proxy.start();
+
+        client = S3Client.builder()
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create("identity", "credential")))
+                .region(Region.US_EAST_1)
+                .endpointOverride(URI.create(
+                        "http://127.0.0.1:" + s3Proxy.getPort()))
+                .serviceConfiguration(S3Configuration.builder()
+                        .pathStyleAccessEnabled(true)
+                        .build())
+                .build();
+
+        client.createBucket(b -> b.bucket(containerName));
+    }
+
+    /** The store that encrypts, in front of the proxy. */
+    private void startEncrypting() throws Exception {
+        start(new TransientNio2BlobStore());
+    }
+
+    /** The store that refuses to, in front of the proxy. */
+    private void startRefusing() throws Exception {
+        start(new FilesystemNio2BlobStore(root.toString()));
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        if (client != null) {
+            client.close();
+        }
+        if (s3Proxy != null) {
+            s3Proxy.stop();
+        }
+    }
+
+    @Test
+    public void testStoresDifferOverEncryption() {
+        assertThat(new TransientNio2BlobStore()
+                .supportsServerSideEncryption()).isTrue();
+        assertThat(new FilesystemNio2BlobStore(root.toString())
+                .supportsServerSideEncryption()).isFalse();
+    }
+
+    @Test
+    public void testReportsDefaultEncryption() throws Exception {
+        startEncrypting();
+
+        // Ask for nothing and the object still rests under the default, the
+        // way S3 encrypts what nobody asked it to.
+        var put = client.putObject(b -> b.bucket(containerName).key("blob"),
+                RequestBody.fromString("payload"));
+        assertThat(put.serverSideEncryption())
+                .isEqualTo(ServerSideEncryption.AES256);
+        assertThat(put.ssekmsKeyId()).isNull();
+
+        var head = client.headObject(b -> b.bucket(containerName).key("blob"));
+        assertThat(head.serverSideEncryption())
+                .isEqualTo(ServerSideEncryption.AES256);
+
+        var get = client.getObjectAsBytes(
+                b -> b.bucket(containerName).key("blob"));
+        assertThat(get.response().serverSideEncryption())
+                .isEqualTo(ServerSideEncryption.AES256);
+        assertThat(get.asUtf8String()).isEqualTo("payload");
+    }
+
+    @Test
+    public void testPutRestsUnderRequestedEncryption() throws Exception {
+        startEncrypting();
+
+        var put = client.putObject(b -> b.bucket(containerName).key("blob")
+                        .serverSideEncryption(ServerSideEncryption.AWS_KMS)
+                        .ssekmsKeyId(KMS_KEY_ID)
+                        .ssekmsEncryptionContext(KMS_CONTEXT)
+                        .bucketKeyEnabled(true),
+                RequestBody.fromString("payload"));
+        assertThat(put.serverSideEncryption())
+                .isEqualTo(ServerSideEncryption.AWS_KMS);
+        assertThat(put.ssekmsKeyId()).isEqualTo(KMS_KEY_ID);
+        assertThat(put.ssekmsEncryptionContext()).isEqualTo(KMS_CONTEXT);
+        assertThat(put.bucketKeyEnabled()).isTrue();
+
+        // Reported from what the object rests under, not from the request
+        // that wrote it: a later read has only the store to ask.
+        var head = client.headObject(b -> b.bucket(containerName).key("blob"));
+        assertThat(head.serverSideEncryption())
+                .isEqualTo(ServerSideEncryption.AWS_KMS);
+        assertThat(head.ssekmsKeyId()).isEqualTo(KMS_KEY_ID);
+        assertThat(head.bucketKeyEnabled()).isTrue();
+
+        var get = client.getObjectAsBytes(
+                b -> b.bucket(containerName).key("blob"));
+        assertThat(get.response().serverSideEncryption())
+                .isEqualTo(ServerSideEncryption.AWS_KMS);
+        assertThat(get.response().ssekmsKeyId()).isEqualTo(KMS_KEY_ID);
+        assertThat(get.asUtf8String()).isEqualTo("payload");
+    }
+
+    @Test
+    public void testCopyRestsUnderItsOwnEncryption() throws Exception {
+        startEncrypting();
+        client.putObject(b -> b.bucket(containerName).key("blob"),
+                RequestBody.fromString("payload"));
+
+        var copy = client.copyObject(b -> b
+                .sourceBucket(containerName).sourceKey("blob")
+                .destinationBucket(containerName).destinationKey("copy")
+                .serverSideEncryption(ServerSideEncryption.AWS_KMS)
+                .ssekmsKeyId(KMS_KEY_ID));
+        assertThat(copy.serverSideEncryption())
+                .isEqualTo(ServerSideEncryption.AWS_KMS);
+        assertThat(copy.ssekmsKeyId()).isEqualTo(KMS_KEY_ID);
+
+        var head = client.headObject(b -> b.bucket(containerName).key("copy"));
+        assertThat(head.serverSideEncryption())
+                .isEqualTo(ServerSideEncryption.AWS_KMS);
+        assertThat(head.ssekmsKeyId()).isEqualTo(KMS_KEY_ID);
+
+        // The source is a different object and keeps its own, which the copy
+        // neither inherited nor disturbed.
+        var source = client.headObject(
+                b -> b.bucket(containerName).key("blob"));
+        assertThat(source.serverSideEncryption())
+                .isEqualTo(ServerSideEncryption.AES256);
+        assertThat(source.ssekmsKeyId()).isNull();
+    }
+
+    @Test
+    public void testMultipartRestsUnderTheUploadsEncryption() throws Exception {
+        startEncrypting();
+
+        var create = client.createMultipartUpload(
+                b -> b.bucket(containerName).key("mpu")
+                        .serverSideEncryption(ServerSideEncryption.AWS_KMS)
+                        .ssekmsKeyId(KMS_KEY_ID));
+        assertThat(create.serverSideEncryption())
+                .isEqualTo(ServerSideEncryption.AWS_KMS);
+        assertThat(create.ssekmsKeyId()).isEqualTo(KMS_KEY_ID);
+
+        // The part and the completion name the encryption the upload was
+        // created under, which only the upload itself still knows: the
+        // requests carrying them name nothing but the bucket and key.
+        var part = client.uploadPart(
+                b -> b.bucket(containerName).key("mpu")
+                        .uploadId(create.uploadId()).partNumber(1),
+                RequestBody.fromString("payload"));
+        assertThat(part.serverSideEncryption())
+                .isEqualTo(ServerSideEncryption.AWS_KMS);
+        assertThat(part.ssekmsKeyId()).isEqualTo(KMS_KEY_ID);
+
+        var complete = client.completeMultipartUpload(
+                b -> b.bucket(containerName).key("mpu")
+                        .uploadId(create.uploadId())
+                        .multipartUpload(CompletedMultipartUpload.builder()
+                                .parts(CompletedPart.builder()
+                                        .partNumber(1)
+                                        .eTag(part.eTag())
+                                        .build())
+                                .build()));
+        assertThat(complete.serverSideEncryption())
+                .isEqualTo(ServerSideEncryption.AWS_KMS);
+        assertThat(complete.ssekmsKeyId()).isEqualTo(KMS_KEY_ID);
+
+        var head = client.headObject(b -> b.bucket(containerName).key("mpu"));
+        assertThat(head.serverSideEncryption())
+                .isEqualTo(ServerSideEncryption.AWS_KMS);
+        assertThat(head.ssekmsKeyId()).isEqualTo(KMS_KEY_ID);
+
+        var get = client.getObjectAsBytes(
+                b -> b.bucket(containerName).key("mpu"));
+        assertThat(get.asUtf8String()).isEqualTo("payload");
+    }
+
+    @Test
+    public void testRefusesWhereBackendCannotEncrypt() throws Exception {
+        startRefusing();
+
+        // without the header everything still works
+        client.putObject(b -> b.bucket(containerName).key("blob"),
+                RequestBody.fromString("payload"));
+
+        assertRefused(() -> client.putObject(
+                b -> b.bucket(containerName).key("blob")
+                        .serverSideEncryption(ServerSideEncryption.AES256),
+                RequestBody.fromString("payload")));
+        assertRefused(() -> client.putObject(
+                b -> b.bucket(containerName).key("blob")
+                        .serverSideEncryption(ServerSideEncryption.AWS_KMS)
+                        .ssekmsKeyId(KMS_KEY_ID),
+                RequestBody.fromString("payload")));
+        assertRefused(() -> client.copyObject(b -> b
+                .sourceBucket(containerName).sourceKey("blob")
+                .destinationBucket(containerName).destinationKey("copy")
+                .serverSideEncryption(ServerSideEncryption.AES256)));
+        assertRefused(() -> client.createMultipartUpload(
+                b -> b.bucket(containerName).key("mpu")
+                        .serverSideEncryption(ServerSideEncryption.AES256)));
+    }
+
+    /**
+     * A store that cannot encrypt reports nothing rather than the default:
+     * the object rests as plaintext on a disk, and saying AES256 over it
+     * would be the claim the refusal above exists to avoid.
+     */
+    @Test
+    public void testReportsNoEncryptionWhereBackendCannot() throws Exception {
+        startRefusing();
+        client.putObject(b -> b.bucket(containerName).key("blob"),
+                RequestBody.fromString("payload"));
+
+        var head = client.headObject(b -> b.bucket(containerName).key("blob"));
+        assertThat(head.serverSideEncryption()).isNull();
+
+        var get = client.getObjectAsBytes(
+                b -> b.bucket(containerName).key("blob"));
+        assertThat(get.response().serverSideEncryption()).isNull();
+    }
+
+    @Test
+    public void testRefusesReadCarryingEncryptionHeader() throws Exception {
+        startRefusing();
+        client.putObject(b -> b.bucket(containerName).key("blob"),
+                RequestBody.fromString("payload"));
+
+        // The header is refused on every method a store that cannot
+        // encrypt sees, as before it was understood at all.
+        var uri = URI.create("http://127.0.0.1:" + s3Proxy.getPort() + "/" +
+                containerName + "/blob");
+        var response = HttpClient.newHttpClient().send(
+                HttpRequest.newBuilder(uri)
+                        .header("x-amz-server-side-encryption", "AES256")
+                        .GET()
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+        assertThat(response.statusCode()).isEqualTo(501);
+
+        response = HttpClient.newHttpClient().send(
+                HttpRequest.newBuilder(uri).GET().build(),
+                HttpResponse.BodyHandlers.ofString());
+        assertThat(response.statusCode()).isEqualTo(200);
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testCustomerKeysStayRefused() throws Exception {
+        // SSE-C stays out even on a store that encrypts: dropping the
+        // caller's key would claim an encryption nobody performed.
+        startEncrypting();
+
+        byte[] key = "0123456789abcdef0123456789abcdef"
+                .getBytes(StandardCharsets.UTF_8);
+        assertRefused(() -> client.putObject(
+                b -> b.bucket(containerName).key("blob")
+                        .sseCustomerAlgorithm("AES256")
+                        .sseCustomerKey(Base64.getEncoder()
+                                .encodeToString(key))
+                        .sseCustomerKeyMD5(Base64.getEncoder().encodeToString(
+                                Hashing.md5().hashBytes(key).asBytes())),
+                RequestBody.fromString("payload")));
+    }
+
+    private static void assertRefused(ThrowingCallable callable) {
+        assertThatThrownBy(callable)
+                .isInstanceOfSatisfying(S3Exception.class,
+                        e -> assertThat(e.statusCode()).isEqualTo(501));
+    }
+}

--- a/src/test/resources/run-s3-tests.sh
+++ b/src/test/resources/run-s3-tests.sh
@@ -109,6 +109,19 @@ tags='not appendobject'\
 ' and not versioning'\
 ' and not webidentity_test'
 
+# Admits the SSE-S3 tests on a lane whose store encrypts.  Dropping the tag
+# is not enough on its own: eighteen of the twenty-one tests carry the
+# encryption tag as well, so the expression has to let sse_s3 back through
+# that exclusion rather than lift it.  What the encryption tag covers beyond
+# SSE-S3 stays out, being SSE-C, which s3proxy refuses everywhere by design;
+# so does bucket_encryption, whose tests ask a bucket to encrypt by default
+# -- the unimplemented ?encryption subresource rather than the header family.
+enable_sse_s3_tests() {
+    tags="${tags/ and not sse_s3/}"
+    tags="${tags/ and not encryption/ and not (encryption and not sse_s3)}"
+    tags="${tags} and not bucket_encryption"
+}
+
 backend=""
 # A -k expression for tests a marker cannot describe, empty for most lanes.
 deselect_by_name=""
@@ -130,6 +143,10 @@ elif [[ "${S3PROXY_CONF}" == s3proxy-localstack*.conf ]]; then
     # so run the tests for it here as well as on the transient lane.  This is
     # the only lane that covers the pass-through path.
     tags="${tags/ and not versioning/}"
+    # The same goes for server-side encryption: LocalStack encrypts, so the
+    # SSE-S3 tests exercise the pass-through here rather than watching a
+    # store that cannot encrypt refuse it.
+    enable_sse_s3_tests
     # Five threads delete the same versions at once and each expects to have
     # deleted them all.  LocalStack refuses a version it no longer has, where
     # S3 counts deleting one that is already gone as a success -- so whether
@@ -151,6 +168,12 @@ elif [ "${S3PROXY_CONF}" = "s3proxy-filesystem.conf" ] ||
         # versions would outlive the process and settle a layout S3Proxy
         # would owe its users; there the requests are still 501.
         tags="${tags/ and not versioning/}"
+        # Server-side encryption parts the two stores on the same line: the
+        # transient store answers the header family, since what it holds
+        # never rests anywhere a caller could read it, while the filesystem
+        # store would be reporting AES256 over plaintext on a real disk and
+        # answers 501 instead.  So these run here and not below.
+        enable_sse_s3_tests
     else
         backend="nio2,filesystem"
     fi

--- a/src/test/resources/s3-tests.conf
+++ b/src/test/resources/s3-tests.conf
@@ -35,6 +35,12 @@ display_name = CustomersName@amazon.com
 access_key = local-identity
 secret_key = local-credential
 
+## The copy tests compare the key id a response reports against this value.
+## S3 answers with the key's ARN rather than the bare id it was given, and
+## LocalStack -- the only backend these tests run against, since it is the
+## only one that encrypts -- does the same, from a fixed account id.
+kms_keyid2 = arn:aws:kms:us-east-1:000000000000:key/testkey-2
+
 [s3 alt]
 ## another user account, used for ACL-related tests
 user_id = 56789abcdef0123456789abcdef0123456789abcdef0123456789abcdef01234


### PR DESCRIPTION
The blobstore interface has spoken the SDK's own request and response types
since the jclouds removal, so SSE-S3 and SSE-KMS need no new plumbing: the
put, copy and initiate-multipart handlers copy the
x-amz-server-side-encryption family onto requests they already build, the
aws-s3 store forwards them verbatim like everything else, and every response
reports what the backend answered rather than what was asked -- real S3
encrypts even what nobody asked it to, and only the backend knows which key.
SSE-C stays refused everywhere, because honoring a caller's key means
carrying it on every read and copy, not echoing it back on the write that
supplied it.  The MultipartUpload record grows the backend's creation answer
so the initiate response can carry it.

The transient store answers the family itself rather than forwarding it,
which is what the tests stand on: a store written to stand in for one that
encrypts is a second implementation of the thing under test, agreeing with
the frontend while telling nobody whether a store S3Proxy ships agrees too.
The two nio2 stores part over this on the line they already part over for
versioning.  What the transient store holds never rests anywhere a caller
could reach, its filesystem living and dying with the process, so an
object's encryption is the header family and nothing besides -- which is all
S3 lets a caller observe of SSE-S3 anyway.  The filesystem store writes to a
real disk, where reporting AES256 over plaintext someone could go and read
would be a claim S3Proxy has no business making; it answers the family
NotImplemented as it did while these headers were unrecognized, and reports
no encryption at all rather than the default, the default being that same
claim made unprompted.

An object's encryption rides in user.sse-* xattrs, and an object encrypted
the way every unasked-for object is carries none of them: an absent
algorithm reads back as the default, so the common case costs no attribute.
A multipart upload keeps its own on the stub blob, since the carriers built
for the upload's later requests name only the bucket and key -- by the time
a part is uploaded or the object completed, what the create asked for exists
nowhere else.  The part copy is emulated for a store with no server-side
copy of its own, reading the source back through the ordinary part upload;
the response built around that write dropped the encryption the write had
just reported, which the s3-tests suite caught where the tests here did not.

Both lanes whose store encrypts run the SSE-S3 tests now -- LocalStack,
which the aws-s3 backend forwards to, and the transient store -- and
twenty-nine pass on each.  Admitting the tag takes more than dropping it,
since eighteen of the twenty-one tests carry the encryption tag as well and
the expression has to let sse_s3 back through that exclusion rather than
lift it.  What that tag covers beyond SSE-S3 is SSE-C; bucket_encryption
goes out with it, those tests asking a bucket to encrypt by default, which
is the unimplemented ?encryption subresource rather than the header family.
The thirteen that do not pass are marked: ten copies with SSE-C on one end
and the three bucket encryption configuration tests.  kms_keyid2 becomes the
key's ARN because that is what a response carries -- S3 and LocalStack alike
answer with the ARN rather than the bare id they were handed, and the proxy
was checked against LocalStack directly, with and without it in the way,
returning the two byte for byte.

See #402.