### PR TITLE
Answer SSE-C on the stores that encrypt

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,6 @@ S3Proxy has broad compatibility with the S3 API, however, it does not support:
 * hosting static websites
 * object lock, including legal hold and retention
 * object ownership controls
-* object server-side encryption with a customer-provided key (SSE-C), see [#402](https://github.com/gaul/s3proxy/issues/402)
 * object tagging
 * paginating ListParts with `part-number-marker`
 * public access block
@@ -180,13 +179,18 @@ its versions would outlive the process, settling a layout on disk that
 S3Proxy would owe its users from then on.
 
 Server-side encryption divides the same two from the rest, and divides the
-two nio2 stores on the same line.  `aws-s3` forwards the header family to a
-service that encrypts, while `transient` answers it itself: what it holds
-rests in a filesystem that dies with the process, so an object's encryption
-is the headers and nothing besides, which is all S3 lets a caller observe of
-SSE-S3 anyway.  `filesystem` writes to a real disk, where reporting AES256
-over plaintext someone could go and read would be a claim S3Proxy has no
-business making, so it refuses those headers instead.
+two nio2 stores on the same line.  `aws-s3` forwards the header families --
+SSE-S3, SSE-KMS and SSE-C alike -- to a service that encrypts, while
+`transient` answers them itself: what it holds rests in a filesystem that
+dies with the process, so an object's encryption is the headers and nothing
+besides, which is all S3 lets a caller observe of SSE-S3 anyway.  SSE-C has
+an observable half beyond the headers -- an object stored under a customer's
+key answers only to that key -- and `transient` enforces it, keeping the
+key's MD5 and never the key.  Unlike S3, S3Proxy accepts SSE-C over plain
+HTTP, its TLS commonly terminating elsewhere.  `filesystem` writes to a real
+disk, where reporting AES256 over plaintext someone could go and read would
+be a claim S3Proxy has no business making, so it refuses every one of these
+headers instead.
 
 Two backends copy a part on the server but fall back to streaming it through
 S3Proxy in one case each: `google-cloud-storage` for a range covering less

--- a/src/main/java/org/gaul/s3proxy/AliasBlobStore.java
+++ b/src/main/java/org/gaul/s3proxy/AliasBlobStore.java
@@ -28,7 +28,6 @@ import java.util.Properties;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableList;
-import com.google.common.hash.HashCode;
 
 import org.gaul.s3proxy.blobstore.BlobStore;
 import org.gaul.s3proxy.blobstore.ForwardingBlobStore;
@@ -57,6 +56,7 @@ import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 import software.amazon.awssdk.services.s3.model.Part;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 
 /**
@@ -261,10 +261,9 @@ public final class AliasBlobStore extends ForwardingBlobStore {
 
     @Override
     public UploadPartResponse uploadMultipartPart(MultipartUpload mpu,
-            int partNumber, InputStream is, long contentLength,
-            @Nullable HashCode contentMD5) {
-        return delegate().uploadMultipartPart(getDelegateMpu(mpu), partNumber,
-                is, contentLength, contentMD5);
+            UploadPartRequest request, InputStream is) {
+        return delegate().uploadMultipartPart(getDelegateMpu(mpu), request,
+                is);
     }
 
     @Override

--- a/src/main/java/org/gaul/s3proxy/AwsHttpHeaders.java
+++ b/src/main/java/org/gaul/s3proxy/AwsHttpHeaders.java
@@ -39,6 +39,12 @@ final class AwsHttpHeaders {
     static final String COPY_SOURCE_IF_UNMODIFIED_SINCE =
             "x-amz-copy-source-if-unmodified-since";
     static final String COPY_SOURCE_RANGE = "x-amz-copy-source-range";
+    static final String COPY_SOURCE_SERVER_SIDE_ENCRYPTION_CUSTOMER_ALGORITHM =
+            "x-amz-copy-source-server-side-encryption-customer-algorithm";
+    static final String COPY_SOURCE_SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY =
+            "x-amz-copy-source-server-side-encryption-customer-key";
+    static final String COPY_SOURCE_SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY_MD5 =
+            "x-amz-copy-source-server-side-encryption-customer-key-md5";
     static final String COPY_SOURCE_VERSION_ID =
             "x-amz-copy-source-version-id";
     static final String DATE = "x-amz-date";
@@ -60,6 +66,12 @@ final class AwsHttpHeaders {
             "x-amz-server-side-encryption-bucket-key-enabled";
     static final String SERVER_SIDE_ENCRYPTION_CONTEXT =
             "x-amz-server-side-encryption-context";
+    static final String SERVER_SIDE_ENCRYPTION_CUSTOMER_ALGORITHM =
+            "x-amz-server-side-encryption-customer-algorithm";
+    static final String SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY =
+            "x-amz-server-side-encryption-customer-key";
+    static final String SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY_MD5 =
+            "x-amz-server-side-encryption-customer-key-md5";
     static final String STORAGE_CLASS = "x-amz-storage-class";
     static final String TRAILER = "x-amz-trailer";
     static final String TRANSFER_ENCODING = "x-amz-te";

--- a/src/main/java/org/gaul/s3proxy/EncryptedBlobStore.java
+++ b/src/main/java/org/gaul/s3proxy/EncryptedBlobStore.java
@@ -36,7 +36,6 @@ import javax.crypto.spec.SecretKeySpec;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
-import com.google.common.hash.HashCode;
 
 import org.gaul.s3proxy.blobstore.BlobStore;
 import org.gaul.s3proxy.blobstore.ForwardingBlobStore;
@@ -70,6 +69,7 @@ import software.amazon.awssdk.services.s3.model.Part;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 import software.amazon.awssdk.services.s3.model.S3Object;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 
 @SuppressWarnings("UnstableApiUsage")
@@ -494,21 +494,24 @@ public final class EncryptedBlobStore extends ForwardingBlobStore {
 
     @Override
     public UploadPartResponse uploadMultipartPart(MultipartUpload mpu,
-        int partNumber, InputStream is, long contentLength,
-        @Nullable HashCode contentMD5) {
+        UploadPartRequest request, InputStream is) {
 
         mpu = filterMultipartUpload(mpu);
         InputStream encrypted;
         try {
             // pass the stream through the encryption
-            encrypted = new Encryption(secretKey, is, partNumber).openStream();
+            encrypted = new Encryption(secretKey, is, request.partNumber())
+                .openStream();
         } catch (IOException | GeneralSecurityException e) {
             throw new RuntimeException(e);
         }
         // adjust the encrypted content length by adding the padding block
         // size; also drop the MD5 since encryption changes the bytes
-        return delegate().uploadMultipartPart(mpu, partNumber, encrypted,
-            contentLength + Constants.PADDING_BLOCK_SIZE, null);
+        return delegate().uploadMultipartPart(mpu, request.toBuilder()
+            .contentLength(request.contentLength() +
+                Constants.PADDING_BLOCK_SIZE)
+            .contentMD5(null)
+            .build(), encrypted);
     }
 
     private MultipartUpload filterMultipartUpload(MultipartUpload mpu) {

--- a/src/main/java/org/gaul/s3proxy/EventualBlobStore.java
+++ b/src/main/java/org/gaul/s3proxy/EventualBlobStore.java
@@ -27,8 +27,6 @@ import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import com.google.common.hash.HashCode;
-
 import org.gaul.s3proxy.blobstore.BlobStore;
 import org.gaul.s3proxy.blobstore.ForwardingBlobStore;
 import org.gaul.s3proxy.blobstore.SdkResponses;
@@ -49,6 +47,7 @@ import software.amazon.awssdk.services.s3.model.DeleteObjectResponse;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 
 /**
@@ -218,10 +217,8 @@ final class EventualBlobStore extends ForwardingBlobStore {
 
     @Override
     public UploadPartResponse uploadMultipartPart(MultipartUpload mpu,
-            int partNumber, InputStream is, long contentLength,
-            @Nullable HashCode contentMD5) {
-        return delegate().uploadMultipartPart(mpu, partNumber,
-                is, contentLength, contentMD5);
+            UploadPartRequest request, InputStream is) {
+        return delegate().uploadMultipartPart(mpu, request, is);
     }
 
     @SuppressWarnings("FutureReturnValueIgnored")

--- a/src/main/java/org/gaul/s3proxy/LatencyBlobStore.java
+++ b/src/main/java/org/gaul/s3proxy/LatencyBlobStore.java
@@ -27,7 +27,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.hash.HashCode;
 
 import org.gaul.s3proxy.blobstore.BlobStore;
 import org.gaul.s3proxy.blobstore.ForwardingBlobStore;
@@ -54,6 +53,7 @@ import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 import software.amazon.awssdk.services.s3.model.Part;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 
 public final class LatencyBlobStore extends ForwardingBlobStore {
@@ -257,9 +257,9 @@ public final class LatencyBlobStore extends ForwardingBlobStore {
     }
 
     @Override
-    public UploadPartResponse uploadMultipartPart(MultipartUpload mpu, int partNumber, InputStream is, long contentLength, @Nullable HashCode contentMD5) {
+    public UploadPartResponse uploadMultipartPart(MultipartUpload mpu, UploadPartRequest request, InputStream is) {
         simulateLatency(OP_UPLOAD_PART);
-        return super.uploadMultipartPart(mpu, partNumber, new ThrottledInputStream(is, getSpeed(OP_UPLOAD_PART)), contentLength, contentMD5);
+        return super.uploadMultipartPart(mpu, request, new ThrottledInputStream(is, getSpeed(OP_UPLOAD_PART)));
     }
 
     @Override

--- a/src/main/java/org/gaul/s3proxy/NullBlobStore.java
+++ b/src/main/java/org/gaul/s3proxy/NullBlobStore.java
@@ -27,7 +27,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.hash.HashCode;
 import com.google.common.io.ByteSource;
 import com.google.common.primitives.Longs;
 
@@ -52,6 +51,7 @@ import software.amazon.awssdk.services.s3.model.Part;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 import software.amazon.awssdk.services.s3.model.S3Object;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 
 final class NullBlobStore extends ForwardingBlobStore {
@@ -181,8 +181,14 @@ final class NullBlobStore extends ForwardingBlobStore {
         // Re-initiate a single-part upload holding the logical length.
         MultipartUpload mpu2 = super.initiateMultipartUpload(mpu.request());
 
-        var part = super.uploadMultipartPart(mpu2, 1,
-                new ByteArrayInputStream(array), array.length, null);
+        var part = super.uploadMultipartPart(mpu2, UploadPartRequest.builder()
+                        .bucket(mpu2.containerName())
+                        .key(mpu2.blobName())
+                        .uploadId(mpu2.id())
+                        .partNumber(1)
+                        .contentLength((long) array.length)
+                        .build(),
+                new ByteArrayInputStream(array));
 
         return super.completeMultipartUpload(mpu2,
                 SdkRequests.completeRequest(mpu2, List.of(
@@ -204,8 +210,7 @@ final class NullBlobStore extends ForwardingBlobStore {
 
     @Override
     public UploadPartResponse uploadMultipartPart(MultipartUpload mpu,
-            int partNumber, InputStream is, long contentLength,
-            @Nullable HashCode contentMD5) {
+            UploadPartRequest request, InputStream is) {
         long length;
         try (is) {
             length = is.transferTo(OutputStream.nullOutputStream());
@@ -219,13 +224,16 @@ final class NullBlobStore extends ForwardingBlobStore {
         // list and complete will read later
         super.putBlob(PutObjectRequest.builder()
                         .bucket(mpu.containerName())
-                        .key(mpu.id() + "-" + partNumber)
+                        .key(mpu.id() + "-" + request.partNumber())
                         .contentLength((long) array.length)
                         .build(),
                 new ByteArrayInputStream(array));
 
-        return super.uploadMultipartPart(mpu, partNumber,
-                new ByteArrayInputStream(array), array.length, null);
+        return super.uploadMultipartPart(mpu, request.toBuilder()
+                        .contentLength((long) array.length)
+                        .contentMD5(null)
+                        .build(),
+                new ByteArrayInputStream(array));
     }
 
     @Override

--- a/src/main/java/org/gaul/s3proxy/PrefixBlobStore.java
+++ b/src/main/java/org/gaul/s3proxy/PrefixBlobStore.java
@@ -27,7 +27,6 @@ import java.util.Properties;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
-import com.google.common.hash.HashCode;
 
 import org.gaul.s3proxy.blobstore.BlobStore;
 import org.gaul.s3proxy.blobstore.ForwardingBlobStore;
@@ -54,6 +53,7 @@ import software.amazon.awssdk.services.s3.model.Part;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 import software.amazon.awssdk.services.s3.model.S3Object;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 
 /**
@@ -311,11 +311,9 @@ public final class PrefixBlobStore extends ForwardingBlobStore {
 
     @Override
     public UploadPartResponse uploadMultipartPart(MultipartUpload mpu,
-            int partNumber, InputStream is, long contentLength,
-            @Nullable HashCode contentMD5) {
+            UploadPartRequest request, InputStream is) {
         return super.uploadMultipartPart(
-                toDelegateMultipartUpload(mpu), partNumber, is, contentLength,
-                contentMD5);
+                toDelegateMultipartUpload(mpu), request, is);
     }
 
     @Override

--- a/src/main/java/org/gaul/s3proxy/ReadOnlyBlobStore.java
+++ b/src/main/java/org/gaul/s3proxy/ReadOnlyBlobStore.java
@@ -18,8 +18,6 @@ package org.gaul.s3proxy;
 
 import java.io.InputStream;
 
-import com.google.common.hash.HashCode;
-
 import org.gaul.s3proxy.blobstore.BlobStore;
 import org.gaul.s3proxy.blobstore.ForwardingBlobStore;
 import org.gaul.s3proxy.blobstore.domain.MultipartUpload;
@@ -41,6 +39,7 @@ import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 
 /** This class is a BlobStore wrapper which prevents mutating operations. */
@@ -148,8 +147,7 @@ final class ReadOnlyBlobStore extends ForwardingBlobStore {
 
     @Override
     public UploadPartResponse uploadMultipartPart(MultipartUpload mpu,
-            int partNumber, InputStream is, long contentLength,
-            @Nullable HashCode contentMD5) {
+            UploadPartRequest request, InputStream is) {
         throw new UnsupportedOperationException("read-only BlobStore");
     }
 }

--- a/src/main/java/org/gaul/s3proxy/RegexBlobStore.java
+++ b/src/main/java/org/gaul/s3proxy/RegexBlobStore.java
@@ -29,8 +29,6 @@ import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.google.common.hash.HashCode;
-
 import org.gaul.s3proxy.blobstore.BlobStore;
 import org.gaul.s3proxy.blobstore.ForwardingBlobStore;
 import org.gaul.s3proxy.blobstore.domain.MultipartUpload;
@@ -54,6 +52,7 @@ import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 import software.amazon.awssdk.services.s3.model.Part;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 
 /**
@@ -218,10 +217,9 @@ public final class RegexBlobStore extends ForwardingBlobStore {
 
     @Override
     public UploadPartResponse uploadMultipartPart(MultipartUpload mpu,
-            int partNumber, InputStream is, long contentLength,
-            @Nullable HashCode contentMD5) {
+            UploadPartRequest request, InputStream is) {
         return super.uploadMultipartPart(rewriteMultipartUpload(mpu),
-                partNumber, is, contentLength, contentMD5);
+                request, is);
     }
 
     @Override

--- a/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
+++ b/src/main/java/org/gaul/s3proxy/S3ProxyHandler.java
@@ -96,6 +96,7 @@ import org.eclipse.jetty.io.content.InputStreamContentSource;
 import org.eclipse.jetty.util.Promise;
 import org.gaul.s3proxy.blobstore.BlobStore;
 import org.gaul.s3proxy.blobstore.ContentMetadata;
+import org.gaul.s3proxy.blobstore.CustomerKeys;
 import org.gaul.s3proxy.blobstore.S3Exceptions;
 import org.gaul.s3proxy.blobstore.SdkResponses;
 import org.gaul.s3proxy.blobstore.domain.MultipartUpload;
@@ -148,10 +149,12 @@ import software.amazon.awssdk.services.s3.model.Part;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 import software.amazon.awssdk.services.s3.model.S3Error;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.model.S3Object;
 import software.amazon.awssdk.services.s3.model.StorageClass;
 import software.amazon.awssdk.services.s3.model.UploadPartCopyRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartCopyResponse;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 import tools.jackson.core.exc.StreamReadException;
 import tools.jackson.databind.DatabindException;
@@ -283,6 +286,11 @@ public class S3ProxyHandler {
             AwsHttpHeaders.COPY_SOURCE_IF_NONE_MATCH,
             AwsHttpHeaders.COPY_SOURCE_IF_UNMODIFIED_SINCE,
             AwsHttpHeaders.COPY_SOURCE_RANGE,
+            AwsHttpHeaders
+                    .COPY_SOURCE_SERVER_SIDE_ENCRYPTION_CUSTOMER_ALGORITHM,
+            AwsHttpHeaders.COPY_SOURCE_SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY,
+            AwsHttpHeaders
+                    .COPY_SOURCE_SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY_MD5,
             AwsHttpHeaders.DATE,
             AwsHttpHeaders.DECODED_CONTENT_LENGTH,
             AwsHttpHeaders.IF_MATCH_LAST_MODIFIED_TIME,
@@ -294,11 +302,30 @@ public class S3ProxyHandler {
             AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_AWS_KMS_KEY_ID,
             AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_BUCKET_KEY_ENABLED,
             AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_CONTEXT,
+            AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_CUSTOMER_ALGORITHM,
+            AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY,
+            AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY_MD5,
             AwsHttpHeaders.STORAGE_CLASS,
             AwsHttpHeaders.TRAILER,
             AwsHttpHeaders.TRANSFER_ENCODING,  // TODO: ignoring header
             AwsHttpHeaders.USER_AGENT
     );
+    /** The request family checkServerSideEncryption vets, whole. */
+    private static final List<String> SERVER_SIDE_ENCRYPTION_HEADERS =
+            List.of(
+                    AwsHttpHeaders.SERVER_SIDE_ENCRYPTION,
+                    AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_AWS_KMS_KEY_ID,
+                    AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_BUCKET_KEY_ENABLED,
+                    AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_CONTEXT,
+                    AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_CUSTOMER_ALGORITHM,
+                    AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY,
+                    AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY_MD5,
+                    AwsHttpHeaders
+                            .COPY_SOURCE_SERVER_SIDE_ENCRYPTION_CUSTOMER_ALGORITHM,
+                    AwsHttpHeaders
+                            .COPY_SOURCE_SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY,
+                    AwsHttpHeaders
+                            .COPY_SOURCE_SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY_MD5);
     private static final Set<String> CANNED_ACLS = Set.of(
             "private",
             "public-read",
@@ -3042,9 +3069,16 @@ public class S3ProxyHandler {
             HttpServletResponse response,
             BlobStore blobStore, String containerName,
             String blobName) throws IOException {
+        checkNoWriteEncryptionHeaders(request);
         var headRequest = HeadObjectRequest.builder()
                 .bucket(containerName)
-                .key(blobName);
+                .key(blobName)
+                .sseCustomerAlgorithm(request.getHeader(AwsHttpHeaders
+                        .SERVER_SIDE_ENCRYPTION_CUSTOMER_ALGORITHM))
+                .sseCustomerKey(request.getHeader(
+                        AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY))
+                .sseCustomerKeyMD5(request.getHeader(AwsHttpHeaders
+                        .SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY_MD5));
         if (blobStore.supportsVersioning()) {
             headRequest.versionId(request.getParameter("versionId"));
         }
@@ -3053,6 +3087,9 @@ public class S3ProxyHandler {
         if (metadata == null) {
             throw new S3ProxyException(S3ErrorCode.NO_SUCH_KEY);
         }
+        // Judged here rather than in the store, whose blobMetadata also
+        // serves the frontend's own bookkeeping reads, which carry no key.
+        enforceCustomerKey(request, metadata.sseCustomerKeyMD5());
         checkPartNumber(request, metadata);
 
         if (checkConditionalHeaders(request, response, metadata)) {
@@ -3142,27 +3179,77 @@ public class S3ProxyHandler {
     }
 
     /**
-     * Vet the x-amz-server-side-encryption request family: only a store
-     * that forwards it to a backend performing the encryption may see it,
-     * on any method, as before these headers were understood at all.
-     * SSE-C stays refused everywhere by its headers' absence from
-     * SUPPORTED_X_AMZ_HEADERS -- silently dropping a caller's key would
-     * claim an encryption nobody performed.
+     * Vet the x-amz-server-side-encryption request family, the customer-key
+     * triple and its copy-source variants included: only a store that
+     * forwards them to a backend performing the encryption -- or performs
+     * it itself -- may see them, on any method, as before these headers
+     * were understood at all.  Silently dropping them would claim an
+     * encryption nobody performed, or read around a key the write named.
      */
     private static void checkServerSideEncryption(HttpServletRequest request,
             BlobStore blobStore) {
-        if (blobStore.supportsServerSideEncryption()) {
+        if (!blobStore.supportsServerSideEncryption()) {
+            for (String header : SERVER_SIDE_ENCRYPTION_HEADERS) {
+                if (request.getHeader(header) != null) {
+                    throw new S3ProxyException(S3ErrorCode.NOT_IMPLEMENTED,
+                            "Server-side encryption is not supported.");
+                }
+            }
             return;
         }
+        // Vet what any request may say against itself: an algorithm S3
+        // does not have, or a KMS key under an algorithm that does not
+        // name one, is malformed wherever it lands.  S3 refuses both and
+        // LocalStack accepts them, so the pass-through lane needs the
+        // refusal here to answer as S3 does.
+        String algorithm = request.getHeader(
+                AwsHttpHeaders.SERVER_SIDE_ENCRYPTION);
+        boolean kms = algorithm != null && algorithm.startsWith("aws:kms");
+        if (algorithm != null && !kms && !algorithm.equals("AES256")) {
+            throw new S3ProxyException(S3ErrorCode.INVALID_ARGUMENT,
+                    "The encryption algorithm specified is not valid.");
+        }
+        if (!kms && (request.getHeader(AwsHttpHeaders
+                        .SERVER_SIDE_ENCRYPTION_AWS_KMS_KEY_ID) != null ||
+                request.getHeader(AwsHttpHeaders
+                        .SERVER_SIDE_ENCRYPTION_CONTEXT) != null)) {
+            throw new S3ProxyException(S3ErrorCode.INVALID_ARGUMENT,
+                    "A KMS key or context requires" +
+                    " x-amz-server-side-encryption: aws:kms.");
+        }
+    }
+
+    /**
+     * Judge a caller's read against the customer key its headers present,
+     * from the key MD5 the store reports the object resting under.
+     */
+    private static void enforceCustomerKey(HttpServletRequest request,
+            @Nullable String storedKeyMD5) {
+        CustomerKeys.enforce(storedKeyMD5,
+                request.getHeader(AwsHttpHeaders
+                        .SERVER_SIDE_ENCRYPTION_CUSTOMER_ALGORITHM),
+                request.getHeader(
+                        AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY),
+                request.getHeader(AwsHttpHeaders
+                        .SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY_MD5));
+    }
+
+    /**
+     * The write-side encryption headers mean nothing on a read -- an
+     * object's encryption is reported, not asked for -- and S3 refuses
+     * them rather than ignoring them.  The customer-key triple is the
+     * exception, being how a read presents the key an object rests under.
+     */
+    private static void checkNoWriteEncryptionHeaders(
+            HttpServletRequest request) {
         if (request.getHeader(AwsHttpHeaders.SERVER_SIDE_ENCRYPTION) != null ||
                 request.getHeader(AwsHttpHeaders
                         .SERVER_SIDE_ENCRYPTION_AWS_KMS_KEY_ID) != null ||
                 request.getHeader(AwsHttpHeaders
-                        .SERVER_SIDE_ENCRYPTION_BUCKET_KEY_ENABLED) != null ||
-                request.getHeader(AwsHttpHeaders
                         .SERVER_SIDE_ENCRYPTION_CONTEXT) != null) {
-            throw new S3ProxyException(S3ErrorCode.NOT_IMPLEMENTED,
-                    "Server-side encryption is not supported.");
+            throw new S3ProxyException(S3ErrorCode.INVALID_REQUEST,
+                    "Server-side encryption headers do not apply to a" +
+                    " read.");
         }
     }
 
@@ -3179,11 +3266,17 @@ public class S3ProxyHandler {
         return value == null ? null : Boolean.valueOf(value);
     }
 
-    /** Report the encryption the backend answered, field by field. */
+    /**
+     * Report the encryption the backend answered, field by field.  A
+     * customer-key response carries the algorithm and the key's MD5 and
+     * never the key, which S3 does not echo either.
+     */
     private static void addServerSideEncryptionHeaders(
             HttpServletResponse response, @Nullable String algorithm,
             @Nullable String kmsKeyId, @Nullable String kmsContext,
-            @Nullable Boolean bucketKeyEnabled) {
+            @Nullable Boolean bucketKeyEnabled,
+            @Nullable String customerAlgorithm,
+            @Nullable String customerKeyMD5) {
         if (algorithm != null) {
             response.addHeader(AwsHttpHeaders.SERVER_SIDE_ENCRYPTION,
                     algorithm);
@@ -3201,6 +3294,16 @@ public class S3ProxyHandler {
             response.addHeader(
                     AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_BUCKET_KEY_ENABLED,
                     bucketKeyEnabled.toString());
+        }
+        if (customerAlgorithm != null) {
+            response.addHeader(
+                    AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_CUSTOMER_ALGORITHM,
+                    customerAlgorithm);
+        }
+        if (customerKeyMD5 != null) {
+            response.addHeader(
+                    AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY_MD5,
+                    customerKeyMD5);
         }
     }
 
@@ -3466,11 +3569,22 @@ public class S3ProxyHandler {
             HttpServletResponse response, BlobStore blobStore,
             String containerName, String blobName)
             throws IOException {
+        checkNoWriteEncryptionHeaders(request);
         if (request.getParameter("partNumber") != null) {
             // needs the ETag to tell a multipart object apart, and the body
             // must not be fetched only to be thrown away on the error path
-            checkPartNumber(request,
-                    blobStore.blobMetadata(containerName, blobName));
+            checkPartNumber(request, blobStore.blobMetadata(
+                    HeadObjectRequest.builder()
+                            .bucket(containerName)
+                            .key(blobName)
+                            .sseCustomerAlgorithm(request.getHeader(
+                                    AwsHttpHeaders
+                                    .SERVER_SIDE_ENCRYPTION_CUSTOMER_ALGORITHM))
+                            .sseCustomerKey(request.getHeader(AwsHttpHeaders
+                                    .SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY))
+                            .sseCustomerKeyMD5(request.getHeader(AwsHttpHeaders
+                                    .SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY_MD5))
+                            .build()));
         }
 
         int status = HttpServletResponse.SC_OK;
@@ -3484,6 +3598,13 @@ public class S3ProxyHandler {
 
         getRequest.ifMatch(request.getHeader(HttpHeaders.IF_MATCH));
         getRequest.ifNoneMatch(request.getHeader(HttpHeaders.IF_NONE_MATCH));
+
+        getRequest.sseCustomerAlgorithm(request.getHeader(AwsHttpHeaders
+                .SERVER_SIDE_ENCRYPTION_CUSTOMER_ALGORITHM))
+                .sseCustomerKey(request.getHeader(
+                        AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY))
+                .sseCustomerKeyMD5(request.getHeader(AwsHttpHeaders
+                        .SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY_MD5));
 
         long ifModifiedSince = request.getDateHeader(
                 HttpHeaders.IF_MODIFIED_SINCE);
@@ -3536,6 +3657,22 @@ public class S3ProxyHandler {
                 getRequest.build());
         if (blob == null) {
             throw new S3ProxyException(S3ErrorCode.NO_SUCH_KEY);
+        }
+
+        // Judged here rather than in the store, whose reads also serve the
+        // frontend's own bookkeeping -- the stub before a completion, the
+        // ETag before a conditional write -- which reads without a key the
+        // way S3's own internals do.  The aws-s3 backend's service has
+        // already judged, and this recheck of its verdict passes.
+        try {
+            enforceCustomerKey(request, blob.response().sseCustomerKeyMD5());
+        } catch (S3Exception e) {
+            try {
+                blob.close();
+            } catch (IOException ioe) {
+                // The stream is being abandoned; ignore close failures.
+            }
+            throw e;
         }
 
         response.setStatus(status);
@@ -3695,14 +3832,28 @@ public class S3ProxyHandler {
         }
 
         // The destination's encryption, applied whatever the metadata
-        // directive says, as on S3.
+        // directive says, as on S3; the copy-source variants present the
+        // key the source rests under.
         copyRequest.serverSideEncryption(
                 request.getHeader(AwsHttpHeaders.SERVER_SIDE_ENCRYPTION))
                 .ssekmsKeyId(request.getHeader(
                         AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_AWS_KMS_KEY_ID))
                 .ssekmsEncryptionContext(request.getHeader(
                         AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_CONTEXT))
-                .bucketKeyEnabled(parseBucketKeyEnabled(request));
+                .bucketKeyEnabled(parseBucketKeyEnabled(request))
+                .sseCustomerAlgorithm(request.getHeader(AwsHttpHeaders
+                        .SERVER_SIDE_ENCRYPTION_CUSTOMER_ALGORITHM))
+                .sseCustomerKey(request.getHeader(
+                        AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY))
+                .sseCustomerKeyMD5(request.getHeader(AwsHttpHeaders
+                        .SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY_MD5))
+                .copySourceSSECustomerAlgorithm(request.getHeader(
+                        AwsHttpHeaders
+                        .COPY_SOURCE_SERVER_SIDE_ENCRYPTION_CUSTOMER_ALGORITHM))
+                .copySourceSSECustomerKey(request.getHeader(AwsHttpHeaders
+                        .COPY_SOURCE_SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY))
+                .copySourceSSECustomerKeyMD5(request.getHeader(AwsHttpHeaders
+                        .COPY_SOURCE_SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY_MD5));
 
         if (replaceMetadata) {
             copyRequest.metadataDirective(MetadataDirective.REPLACE);
@@ -3764,7 +3915,9 @@ public class S3ProxyHandler {
                 copyResult.serverSideEncryptionAsString(),
                 copyResult.ssekmsKeyId(),
                 copyResult.ssekmsEncryptionContext(),
-                copyResult.bucketKeyEnabled());
+                copyResult.bucketKeyEnabled(),
+                copyResult.sseCustomerAlgorithm(),
+                copyResult.sseCustomerKeyMD5());
         try (Writer writer = response.getWriter()) {
             response.setContentType(XML_CONTENT_TYPE);
             XMLStreamWriter xml = xmlOutputFactory.createXMLStreamWriter(
@@ -3961,7 +4114,13 @@ public class S3ProxyHandler {
                         AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_AWS_KMS_KEY_ID))
                 .ssekmsEncryptionContext(request.getHeader(
                         AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_CONTEXT))
-                .bucketKeyEnabled(parseBucketKeyEnabled(request));
+                .bucketKeyEnabled(parseBucketKeyEnabled(request))
+                .sseCustomerAlgorithm(request.getHeader(AwsHttpHeaders
+                        .SERVER_SIDE_ENCRYPTION_CUSTOMER_ALGORITHM))
+                .sseCustomerKey(request.getHeader(
+                        AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY))
+                .sseCustomerKeyMD5(request.getHeader(AwsHttpHeaders
+                        .SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY_MD5));
 
         var contentHeaders = parseContentMetadata(request, checksum,
                 checksumValue);
@@ -3991,7 +4150,8 @@ public class S3ProxyHandler {
         }
         addServerSideEncryptionHeaders(response,
                 result.serverSideEncryptionAsString(), result.ssekmsKeyId(),
-                result.ssekmsEncryptionContext(), result.bucketKeyEnabled());
+                result.ssekmsEncryptionContext(), result.bucketKeyEnabled(),
+                result.sseCustomerAlgorithm(), result.sseCustomerKeyMD5());
         if (checksum != null) {
             response.addHeader(checksum.header(), checksumValue);
         }
@@ -4353,6 +4513,42 @@ public class S3ProxyHandler {
         if (contentType != null) {
             putRequest.contentType(contentType);
         }
+        // The form's encryption fields ride the way the header family does
+        // on a PUT: the backend performs the encryption and judges the
+        // values.  A store that cannot encrypt refuses them here the way
+        // checkServerSideEncryption refuses the headers, rather than
+        // storing plaintext that asked to be encrypted.
+        String serverSideEncryption = fields.get(
+                AwsHttpHeaders.SERVER_SIDE_ENCRYPTION);
+        String ssekmsKeyId = fields.get(
+                AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_AWS_KMS_KEY_ID);
+        String ssekmsContext = fields.get(
+                AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_CONTEXT);
+        String bucketKeyEnabled = fields.get(
+                AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_BUCKET_KEY_ENABLED);
+        String customerAlgorithm = fields.get(
+                AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_CUSTOMER_ALGORITHM);
+        String customerKey = fields.get(
+                AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY);
+        String customerKeyMD5 = fields.get(
+                AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY_MD5);
+        if (serverSideEncryption != null || ssekmsKeyId != null ||
+                ssekmsContext != null || bucketKeyEnabled != null ||
+                customerAlgorithm != null || customerKey != null ||
+                customerKeyMD5 != null) {
+            if (!blobStore.supportsServerSideEncryption()) {
+                throw new S3ProxyException(S3ErrorCode.NOT_IMPLEMENTED,
+                        "Server-side encryption is not supported.");
+            }
+            putRequest.serverSideEncryption(serverSideEncryption)
+                    .ssekmsKeyId(ssekmsKeyId)
+                    .ssekmsEncryptionContext(ssekmsContext)
+                    .bucketKeyEnabled(bucketKeyEnabled == null ? null :
+                            Boolean.valueOf(bucketKeyEnabled))
+                    .sseCustomerAlgorithm(customerAlgorithm)
+                    .sseCustomerKey(customerKey)
+                    .sseCustomerKeyMD5(customerKeyMD5);
+        }
         var userMetadata = new TreeMap<String, String>();
         for (var entry : fields.entrySet()) {
             if (entry.getKey().startsWith(USER_METADATA_PREFIX)) {
@@ -4381,6 +4577,10 @@ public class S3ProxyHandler {
         if (versionId != null) {
             response.addHeader(AwsHttpHeaders.VERSION_ID, versionId);
         }
+        addServerSideEncryptionHeaders(response,
+                result.serverSideEncryptionAsString(), result.ssekmsKeyId(),
+                result.ssekmsEncryptionContext(), result.bucketKeyEnabled(),
+                result.sseCustomerAlgorithm(), result.sseCustomerKeyMD5());
 
         // A browser posting a form has nowhere to display a response body, so
         // the form says where to send the user instead.  The redirect wins
@@ -4483,7 +4683,13 @@ public class S3ProxyHandler {
                         AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_AWS_KMS_KEY_ID))
                 .ssekmsEncryptionContext(request.getHeader(
                         AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_CONTEXT))
-                .bucketKeyEnabled(parseBucketKeyEnabled(request));
+                .bucketKeyEnabled(parseBucketKeyEnabled(request))
+                .sseCustomerAlgorithm(request.getHeader(AwsHttpHeaders
+                        .SERVER_SIDE_ENCRYPTION_CUSTOMER_ALGORITHM))
+                .sseCustomerKey(request.getHeader(
+                        AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY))
+                .sseCustomerKeyMD5(request.getHeader(AwsHttpHeaders
+                        .SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY_MD5));
 
         StorageClass parsedStorageClass = null;
         String storageClass = request.getHeader(AwsHttpHeaders.STORAGE_CLASS);
@@ -4575,7 +4781,9 @@ public class S3ProxyHandler {
                     createResponse.serverSideEncryptionAsString(),
                     createResponse.ssekmsKeyId(),
                     createResponse.ssekmsEncryptionContext(),
-                    createResponse.bucketKeyEnabled());
+                    createResponse.bucketKeyEnabled(),
+                    createResponse.sseCustomerAlgorithm(),
+                    createResponse.sseCustomerKeyMD5());
         }
         try (Writer writer = response.getWriter()) {
             response.setContentType(XML_CONTENT_TYPE);
@@ -4842,6 +5050,14 @@ public class S3ProxyHandler {
                         .build())
                 .ifMatch(completeIfMatch)
                 .ifNoneMatch(completeIfNoneMatch)
+                // The completion must present the create-time customer key
+                // again, as every part did.
+                .sseCustomerAlgorithm(request.getHeader(AwsHttpHeaders
+                        .SERVER_SIDE_ENCRYPTION_CUSTOMER_ALGORITHM))
+                .sseCustomerKey(request.getHeader(
+                        AwsHttpHeaders.SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY))
+                .sseCustomerKeyMD5(request.getHeader(AwsHttpHeaders
+                        .SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY_MD5))
                 .build();
 
         // A conditional completion has to finish before anything is sent: the
@@ -4874,10 +5090,18 @@ public class S3ProxyHandler {
         // encryption -- and a store that supports it always takes it, since
         // it also supports versioning.
         if (completedResult != null) {
+            // The SDK's completion response models no customer-key fields,
+            // so their echo comes from the request: a completion that
+            // presented a key and reached this line rests under it, the
+            // store having refused every other combination.
             addServerSideEncryptionHeaders(response,
                     completedResult.serverSideEncryptionAsString(),
                     completedResult.ssekmsKeyId(), /*kmsContext=*/ null,
-                    completedResult.bucketKeyEnabled());
+                    completedResult.bucketKeyEnabled(),
+                    request.getHeader(AwsHttpHeaders
+                            .SERVER_SIDE_ENCRYPTION_CUSTOMER_ALGORITHM),
+                    request.getHeader(AwsHttpHeaders
+                            .SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY_MD5));
         }
         try (PrintWriter writer = response.getWriter()) {
             response.setStatus(HttpServletResponse.SC_OK);
@@ -5647,7 +5871,13 @@ public class S3ProxyHandler {
         var getRequest = GetObjectRequest.builder()
                 .bucket(sourceContainerName)
                 .key(sourceBlobName)
-                .versionId(sourceVersionId);
+                .versionId(sourceVersionId)
+                .sseCustomerAlgorithm(request.getHeader(AwsHttpHeaders
+                        .COPY_SOURCE_SERVER_SIDE_ENCRYPTION_CUSTOMER_ALGORITHM))
+                .sseCustomerKey(request.getHeader(AwsHttpHeaders
+                        .COPY_SOURCE_SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY))
+                .sseCustomerKeyMD5(request.getHeader(AwsHttpHeaders
+                        .COPY_SOURCE_SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY_MD5));
         String range = request.getHeader(AwsHttpHeaders.COPY_SOURCE_RANGE);
         String rawCopySourceRange = range;
         long expectedSize = -1;
@@ -5725,6 +5955,15 @@ public class S3ProxyHandler {
                                 .bucket(sourceContainerName)
                                 .key(sourceBlobName)
                                 .versionId(sourceVersionId)
+                                .sseCustomerAlgorithm(request.getHeader(
+                                        AwsHttpHeaders
+                                        .COPY_SOURCE_SERVER_SIDE_ENCRYPTION_CUSTOMER_ALGORITHM))
+                                .sseCustomerKey(request.getHeader(
+                                        AwsHttpHeaders
+                                        .COPY_SOURCE_SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY))
+                                .sseCustomerKeyMD5(request.getHeader(
+                                        AwsHttpHeaders
+                                        .COPY_SOURCE_SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY_MD5))
                                 .build());
                 if (sourceMetadata == null) {
                     throw new S3ProxyException(S3ErrorCode.NO_SUCH_KEY);
@@ -5756,6 +5995,20 @@ public class S3ProxyHandler {
                     .copySourceIfUnmodifiedSince(
                             nativeIfUnmodifiedSince == -1 ? null :
                             Instant.ofEpochMilli(nativeIfUnmodifiedSince))
+                    .sseCustomerAlgorithm(request.getHeader(AwsHttpHeaders
+                            .SERVER_SIDE_ENCRYPTION_CUSTOMER_ALGORITHM))
+                    .sseCustomerKey(request.getHeader(AwsHttpHeaders
+                            .SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY))
+                    .sseCustomerKeyMD5(request.getHeader(AwsHttpHeaders
+                            .SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY_MD5))
+                    .copySourceSSECustomerAlgorithm(request.getHeader(
+                            AwsHttpHeaders
+                            .COPY_SOURCE_SERVER_SIDE_ENCRYPTION_CUSTOMER_ALGORITHM))
+                    .copySourceSSECustomerKey(request.getHeader(AwsHttpHeaders
+                            .COPY_SOURCE_SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY))
+                    .copySourceSSECustomerKeyMD5(request.getHeader(
+                            AwsHttpHeaders
+                            .COPY_SOURCE_SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY_MD5))
                     .build();
             UploadPartCopyResponse part;
             try {
@@ -5778,6 +6031,25 @@ public class S3ProxyHandler {
         }
 
         GetObjectResponse blobMetadata = blob.response();
+        // The source answers only to the key the copy-source headers
+        // present, judged here for the store that answers the family
+        // itself; the aws-s3 backend's service judged the read already.
+        try {
+            CustomerKeys.enforce(blobMetadata.sseCustomerKeyMD5(),
+                    request.getHeader(AwsHttpHeaders
+                            .COPY_SOURCE_SERVER_SIDE_ENCRYPTION_CUSTOMER_ALGORITHM),
+                    request.getHeader(AwsHttpHeaders
+                            .COPY_SOURCE_SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY),
+                    request.getHeader(AwsHttpHeaders
+                            .COPY_SOURCE_SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY_MD5));
+        } catch (S3Exception se) {
+            try {
+                blob.close();
+            } catch (IOException ioe) {
+                // The stream is being abandoned; ignore close failures.
+            }
+            throw se;
+        }
         String eTag = blobMetadata.eTag();
         Date lastModified = blobMetadata.lastModified() == null ? null :
                 Date.from(blobMetadata.lastModified());
@@ -5832,8 +6104,23 @@ public class S3ProxyHandler {
 
         UploadPartResponse part;
         try (InputStream is = blob) {
-            part = blobStore.uploadMultipartPart(mpu, partNumber, is,
-                    contentLength, null);
+            part = blobStore.uploadMultipartPart(mpu,
+                    UploadPartRequest.builder()
+                            .bucket(containerName)
+                            .key(blobName)
+                            .uploadId(uploadId)
+                            .partNumber(partNumber)
+                            .contentLength(contentLength)
+                            .sseCustomerAlgorithm(request.getHeader(
+                                    AwsHttpHeaders
+                                    .SERVER_SIDE_ENCRYPTION_CUSTOMER_ALGORITHM))
+                            .sseCustomerKey(request.getHeader(AwsHttpHeaders
+                                    .SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY))
+                            .sseCustomerKeyMD5(request.getHeader(
+                                    AwsHttpHeaders
+                                    .SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY_MD5))
+                            .build(),
+                    is);
             eTag = part.eTag();
         }
 
@@ -5847,6 +6134,8 @@ public class S3ProxyHandler {
                                 part.serverSideEncryptionAsString())
                         .ssekmsKeyId(part.ssekmsKeyId())
                         .bucketKeyEnabled(part.bucketKeyEnabled())
+                        .sseCustomerAlgorithm(part.sseCustomerAlgorithm())
+                        .sseCustomerKeyMD5(part.sseCustomerKeyMD5())
                         .build());
     }
 
@@ -5862,7 +6151,8 @@ public class S3ProxyHandler {
         }
         addServerSideEncryptionHeaders(response,
                 part.serverSideEncryptionAsString(), part.ssekmsKeyId(),
-                /*kmsContext=*/ null, part.bucketKeyEnabled());
+                /*kmsContext=*/ null, part.bucketKeyEnabled(),
+                part.sseCustomerAlgorithm(), part.sseCustomerKeyMD5());
         try (Writer writer = response.getWriter()) {
             response.setContentType(XML_CONTENT_TYPE);
             XMLStreamWriter xml = xmlOutputFactory.createXMLStreamWriter(
@@ -5976,7 +6266,21 @@ public class S3ProxyHandler {
                 uploadId);
 
         UploadPartResponse part = blobStore.uploadMultipartPart(mpu,
-                partNumber, is, contentLength, contentMD5);
+                UploadPartRequest.builder()
+                        .bucket(containerName)
+                        .key(blobName)
+                        .uploadId(uploadId)
+                        .partNumber(partNumber)
+                        .contentLength(contentLength)
+                        .contentMD5(contentMD5String)
+                        .sseCustomerAlgorithm(request.getHeader(AwsHttpHeaders
+                                .SERVER_SIDE_ENCRYPTION_CUSTOMER_ALGORITHM))
+                        .sseCustomerKey(request.getHeader(AwsHttpHeaders
+                                .SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY))
+                        .sseCustomerKeyMD5(request.getHeader(AwsHttpHeaders
+                                .SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY_MD5))
+                        .build(),
+                is);
 
         if (part.eTag() != null) {
             response.addHeader(HttpHeaders.ETAG,
@@ -5987,7 +6291,8 @@ public class S3ProxyHandler {
         }
         addServerSideEncryptionHeaders(response,
                 part.serverSideEncryptionAsString(), part.ssekmsKeyId(),
-                /*kmsContext=*/ null, part.bucketKeyEnabled());
+                /*kmsContext=*/ null, part.bucketKeyEnabled(),
+                part.sseCustomerAlgorithm(), part.sseCustomerKeyMD5());
 
         addCorsResponseHeader(request, response);
     }
@@ -6067,7 +6372,9 @@ public class S3ProxyHandler {
         addServerSideEncryptionHeaders(response,
                 metadata.serverSideEncryptionAsString(),
                 metadata.ssekmsKeyId(), /*kmsContext=*/ null,
-                metadata.bucketKeyEnabled());
+                metadata.bucketKeyEnabled(),
+                metadata.sseCustomerAlgorithm(),
+                metadata.sseCustomerKeyMD5());
         FlexChecksum storedChecksum = null;
         String storedChecksumValue = null;
         for (var entry : metadata.metadata().entrySet()) {

--- a/src/main/java/org/gaul/s3proxy/ShardedBlobStore.java
+++ b/src/main/java/org/gaul/s3proxy/ShardedBlobStore.java
@@ -72,6 +72,7 @@ import software.amazon.awssdk.services.s3.model.Part;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 import software.amazon.awssdk.services.s3.model.S3Object;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 
 /**
@@ -547,12 +548,9 @@ final class ShardedBlobStore extends ForwardingBlobStore {
 
     @Override
     public UploadPartResponse uploadMultipartPart(MultipartUpload mpu,
-            int partNumber, InputStream is, long contentLength,
-            @Nullable HashCode contentMD5) {
+            UploadPartRequest request, InputStream is) {
         if (!this.buckets.containsKey(mpu.containerName())) {
-            return this.delegate()
-                    .uploadMultipartPart(mpu, partNumber, is, contentLength,
-                            contentMD5);
+            return this.delegate().uploadMultipartPart(mpu, request, is);
         }
         throw new UnsupportedOperationException("sharded bucket");
     }

--- a/src/main/java/org/gaul/s3proxy/awssdk/AwsS3SdkBlobStore.java
+++ b/src/main/java/org/gaul/s3proxy/awssdk/AwsS3SdkBlobStore.java
@@ -24,7 +24,6 @@ import java.util.List;
 
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
-import com.google.common.hash.HashCode;
 
 import org.gaul.s3proxy.blobstore.BlobStore;
 import org.gaul.s3proxy.blobstore.Credentials;
@@ -646,16 +645,15 @@ public final class AwsS3SdkBlobStore implements BlobStore {
 
     @Override
     public UploadPartResponse uploadMultipartPart(MultipartUpload mpu,
-            int partNumber, InputStream is, long contentLength,
-            @Nullable HashCode contentMD5) {
+            UploadPartRequest request, InputStream is) {
         try (is) {
-            return s3Client.uploadPart(UploadPartRequest.builder()
+            return s3Client.uploadPart(request.toBuilder()
                     .bucket(mpu.containerName())
                     .key(mpu.blobName())
                     .uploadId(mpu.id())
-                    .partNumber(partNumber)
                     .build(),
-                    RequestBody.fromInputStream(is, contentLength));
+                    RequestBody.fromInputStream(is,
+                            request.contentLength()));
         } catch (IOException e) {
             throw new RuntimeException("Failed to upload part", e);
         } catch (S3Exception e) {

--- a/src/main/java/org/gaul/s3proxy/azureblob/AzureBlobStore.java
+++ b/src/main/java/org/gaul/s3proxy/azureblob/AzureBlobStore.java
@@ -79,7 +79,6 @@ import com.azure.storage.common.policy.RetryPolicyType;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import com.google.common.hash.HashCode;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
 import com.google.common.hash.HashingInputStream;
@@ -128,6 +127,7 @@ import software.amazon.awssdk.services.s3.model.S3Object;
 import software.amazon.awssdk.services.s3.model.StorageClass;
 import software.amazon.awssdk.services.s3.model.UploadPartCopyRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartCopyResponse;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 
 public final class AzureBlobStore implements BlobStore {
@@ -1316,8 +1316,10 @@ public final class AzureBlobStore implements BlobStore {
 
     @Override
     public UploadPartResponse uploadMultipartPart(MultipartUpload mpu,
-            int partNumber, InputStream is, long contentLength,
-            @Nullable HashCode contentMD5) {
+            UploadPartRequest request, InputStream is) {
+        int partNumber = request.partNumber();
+        long contentLength = request.contentLength();
+        var contentMD5 = SdkRequests.contentMD5(request);
 
         if (partNumber < 1 || partNumber > 10_000) {
             throw new IllegalArgumentException(

--- a/src/main/java/org/gaul/s3proxy/blobstore/BlobStore.java
+++ b/src/main/java/org/gaul/s3proxy/blobstore/BlobStore.java
@@ -24,7 +24,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.hash.HashCode;
 
 import org.gaul.s3proxy.blobstore.domain.MultipartUpload;
 import org.jspecify.annotations.Nullable;
@@ -65,6 +64,7 @@ import software.amazon.awssdk.services.s3.model.S3Error;
 import software.amazon.awssdk.services.s3.model.S3Object;
 import software.amazon.awssdk.services.s3.model.UploadPartCopyRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartCopyResponse;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 
 /** Synchronous access to a BlobStore such as Amazon S3. */
@@ -469,14 +469,15 @@ public interface BlobStore extends AutoCloseable {
 
     /**
      * Uploads a part of a multipart upload, consuming and closing
-     * {@code is}.
-     *
-     * @param contentMD5 MD5 of the part content, used for integrity
-     *        validation where the backend supports it
+     * {@code is}.  The request carries the part number, the content
+     * length and MD5, and the customer key when the upload was created
+     * under one -- S3 requires every part to present the create-time key
+     * again.  {@code mpu} carries the upload itself, and its names say
+     * where the part lands; wrappers that rename do so through it, so the
+     * request's own bucket and key are not consulted.
      */
     UploadPartResponse uploadMultipartPart(MultipartUpload mpu,
-            int partNumber, InputStream is, long contentLength,
-            @Nullable HashCode contentMD5);
+            UploadPartRequest request, InputStream is);
 
     /**
      * Whether {@link #copyMultipartPart} copies server-side on the backend.

--- a/src/main/java/org/gaul/s3proxy/blobstore/CustomerKeys.java
+++ b/src/main/java/org/gaul/s3proxy/blobstore/CustomerKeys.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2014-2026 Andrew Gaul <andrew@gaul.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gaul.s3proxy.blobstore;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Base64;
+
+import com.google.common.hash.Hashing;
+
+import org.gaul.s3proxy.blobstore.domain.Encryption;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Judges the SSE-C customer-key triple the way S3 does, for a store that
+ * answers the header family itself.  The stores vet writes -- a put, a
+ * copy's two ends, an upload's create and parts -- and the frontend judges
+ * reads, since only it can tell a caller's read from its own bookkeeping:
+ * the stub consulted before a completion or the ETag before a conditional
+ * write read without a key, the way S3's own internals do.  The aws-s3
+ * backend forwards the triple verbatim and its service judges instead.
+ */
+public final class CustomerKeys {
+    @SuppressWarnings("deprecation")
+    private static final com.google.common.hash.HashFunction MD5 =
+            Hashing.md5();
+
+    private CustomerKeys() {
+    }
+
+    /**
+     * Vets one request's triple -- all three fields together, AES256, a
+     * 256-bit key, an MD5 that matches -- and returns what the object
+     * rests under: the algorithm and the key's MD5, never the key.
+     */
+    public static Encryption vet(@Nullable String customerAlgorithm,
+            @Nullable String customerKey, @Nullable String customerKeyMD5) {
+        if (customerAlgorithm == null || customerKey == null ||
+                customerKeyMD5 == null) {
+            throw S3Exceptions.invalidArgument("Requests specifying Server" +
+                    " Side Encryption with Customer provided keys must" +
+                    " provide the algorithm, the key and the key's MD5.");
+        }
+        if (!Encryption.DEFAULT_ALGORITHM.equals(customerAlgorithm)) {
+            throw S3Exceptions.invalidArgument("The encryption algorithm" +
+                    " specified is not valid.  Valid value: AES256.");
+        }
+        byte[] key;
+        try {
+            key = Base64.getDecoder().decode(customerKey);
+        } catch (IllegalArgumentException iae) {
+            throw S3Exceptions.invalidArgument(
+                    "The secret key was invalid.");
+        }
+        if (key.length != 32) {
+            throw S3Exceptions.invalidArgument(
+                    "The secret key must be 256 bits.");
+        }
+        byte[] keyMD5;
+        try {
+            keyMD5 = Base64.getDecoder().decode(customerKeyMD5);
+        } catch (IllegalArgumentException iae) {
+            throw S3Exceptions.invalidArgument("The calculated MD5 hash of" +
+                    " the key did not match the hash that was provided.");
+        }
+        if (!MessageDigest.isEqual(MD5.hashBytes(key).asBytes(), keyMD5)) {
+            throw S3Exceptions.invalidArgument("The calculated MD5 hash of" +
+                    " the key did not match the hash that was provided.");
+        }
+        return Encryption.forCustomerKey(customerAlgorithm, customerKeyMD5);
+    }
+
+    /**
+     * Judges a read against the key it presents: an object resting under a
+     * customer key answers only to that key, 400 whether the read offered
+     * none or the wrong one, and an object resting under none refuses any
+     * key offered.  {@code storedKeyMD5} is what the object rests under,
+     * null for none.
+     */
+    public static void enforce(@Nullable String storedKeyMD5,
+            @Nullable String customerAlgorithm, @Nullable String customerKey,
+            @Nullable String customerKeyMD5) {
+        if (storedKeyMD5 == null) {
+            if (customerAlgorithm != null || customerKey != null ||
+                    customerKeyMD5 != null) {
+                throw S3Exceptions.invalidRequest("The encryption" +
+                        " parameters are not applicable to this object.");
+            }
+            return;
+        }
+        if (customerAlgorithm == null && customerKey == null &&
+                customerKeyMD5 == null) {
+            throw S3Exceptions.invalidRequest("The object was stored using" +
+                    " a form of Server Side Encryption.  The correct" +
+                    " parameters must be provided to retrieve the object.");
+        }
+        var presented = vet(customerAlgorithm, customerKey, customerKeyMD5);
+        if (!matches(storedKeyMD5, presented.customerKeyMD5())) {
+            throw S3Exceptions.invalidArgument("The provided customer key" +
+                    " does not match the key the object was stored under.");
+        }
+    }
+
+    /** Whether two key MD5s name the same key, compared in fixed time. */
+    public static boolean matches(String storedKeyMD5,
+            @Nullable String presentedKeyMD5) {
+        return presentedKeyMD5 != null && MessageDigest.isEqual(
+                storedKeyMD5.getBytes(StandardCharsets.US_ASCII),
+                presentedKeyMD5.getBytes(StandardCharsets.US_ASCII));
+    }
+}

--- a/src/main/java/org/gaul/s3proxy/blobstore/ForwardingBlobStore.java
+++ b/src/main/java/org/gaul/s3proxy/blobstore/ForwardingBlobStore.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Objects;
 
 import com.google.common.collect.ForwardingObject;
-import com.google.common.hash.HashCode;
 
 import org.gaul.s3proxy.blobstore.domain.MultipartUpload;
 import org.jspecify.annotations.Nullable;
@@ -51,6 +50,7 @@ import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 import software.amazon.awssdk.services.s3.model.Part;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 
 public abstract class ForwardingBlobStore extends ForwardingObject
@@ -232,10 +232,8 @@ public abstract class ForwardingBlobStore extends ForwardingObject
 
     @Override
     public UploadPartResponse uploadMultipartPart(MultipartUpload mpu,
-            int partNumber, InputStream is, long contentLength,
-            @Nullable HashCode contentMD5) {
-        return delegate().uploadMultipartPart(mpu, partNumber, is,
-                contentLength, contentMD5);
+            UploadPartRequest request, InputStream is) {
+        return delegate().uploadMultipartPart(mpu, request, is);
     }
 
     @Override

--- a/src/main/java/org/gaul/s3proxy/blobstore/S3Exceptions.java
+++ b/src/main/java/org/gaul/s3proxy/blobstore/S3Exceptions.java
@@ -124,6 +124,20 @@ public final class S3Exceptions {
     }
 
     /**
+     * A 400 for a request malformed as a whole rather than in one
+     * argument, e.g. reading an object stored under a customer key
+     * without presenting one.  S3 answers these InvalidRequest.
+     */
+    public static S3Exception invalidRequest(String message) {
+        return (S3Exception) S3Exception.builder()
+                .message(message)
+                .statusCode(400)
+                .awsErrorDetails(details(400, "InvalidRequest", message,
+                        Map.of()))
+                .build();
+    }
+
+    /**
      * An error carrying only a status code, which the frontend maps to an
      * S3 error document by status.  Used by backends whose service reported
      * a failure with no S3 error code to pass through.

--- a/src/main/java/org/gaul/s3proxy/blobstore/SdkRequests.java
+++ b/src/main/java/org/gaul/s3proxy/blobstore/SdkRequests.java
@@ -16,7 +16,10 @@
 
 package org.gaul.s3proxy.blobstore;
 
+import java.util.Base64;
 import java.util.List;
+
+import com.google.common.hash.HashCode;
 
 import org.gaul.s3proxy.blobstore.domain.MultipartUpload;
 import org.jspecify.annotations.Nullable;
@@ -25,6 +28,7 @@ import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CompletedMultipartUpload;
 import software.amazon.awssdk.services.s3.model.CompletedPart;
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 
 /**
  * Helpers for the SDK request types the {@link BlobStore} SPI consumes.
@@ -57,6 +61,18 @@ public final class SdkRequests {
             @Nullable ObjectCannedACL acl) {
         return acl == ObjectCannedACL.PUBLIC_READ ? acl :
                 ObjectCannedACL.PRIVATE;
+    }
+
+    /**
+     * A part request's Content-MD5 as the bytes it names, or null when the
+     * request carries none.  The frontend has already rejected anything
+     * that does not decode to an MD5.
+     */
+    @Nullable
+    public static HashCode contentMD5(UploadPartRequest request) {
+        String contentMD5 = request.contentMD5();
+        return contentMD5 == null ? null : HashCode.fromBytes(
+                Base64.getDecoder().decode(contentMD5));
     }
 
     /** An unconditional completion request asserting {@code parts}. */

--- a/src/main/java/org/gaul/s3proxy/blobstore/SdkResponses.java
+++ b/src/main/java/org/gaul/s3proxy/blobstore/SdkResponses.java
@@ -66,6 +66,10 @@ public final class SdkResponses {
                 .ssekmsKeyId(encryption == null ? null : encryption.kmsKeyId())
                 .bucketKeyEnabled(encryption == null ? null :
                         encryption.bucketKeyEnabled())
+                .sseCustomerAlgorithm(encryption == null ? null :
+                        encryption.customerAlgorithm())
+                .sseCustomerKeyMD5(encryption == null ? null :
+                        encryption.customerKeyMD5())
                 .metadata(metadata.userMetadata())
                 .cacheControl(contentMetadata.cacheControl())
                 .contentDisposition(contentMetadata.contentDisposition())
@@ -112,6 +116,8 @@ public final class SdkResponses {
                 .metadata(response.metadata())
                 .serverSideEncryption(response.serverSideEncryptionAsString())
                 .ssekmsKeyId(response.ssekmsKeyId())
+                .sseCustomerAlgorithm(response.sseCustomerAlgorithm())
+                .sseCustomerKeyMD5(response.sseCustomerKeyMD5())
                 .storageClass(response.storageClassAsString())
                 .versionId(response.versionId())
                 .build();

--- a/src/main/java/org/gaul/s3proxy/blobstore/domain/Encryption.java
+++ b/src/main/java/org/gaul/s3proxy/blobstore/domain/Encryption.java
@@ -20,18 +20,29 @@ import org.jspecify.annotations.Nullable;
 
 /**
  * The server-side encryption an object rests under: the algorithm, and the
- * KMS key, context and bucket-key setting when the algorithm names one.
- * Only a store that answers {@code supportsServerSideEncryption()} records
- * this, and every response naming such an object reports it.
+ * KMS key, context and bucket-key setting when the algorithm names one; or,
+ * for an object resting under a customer's own key, the algorithm and the
+ * key's MD5 -- the key itself is never kept, only what judges whether a
+ * later request presents the same one.  The two modes exclude each other
+ * the way S3's headers do: a customer-key object reports no
+ * x-amz-server-side-encryption at all, so {@code algorithm} is null exactly
+ * when {@code customerKeyMD5} is not.  Only a store that answers
+ * {@code supportsServerSideEncryption()} records this, and every response
+ * naming such an object reports it.
  */
 public record Encryption(
-        String algorithm,
+        @Nullable String algorithm,
         @Nullable String kmsKeyId,
         @Nullable String kmsContext,
-        @Nullable Boolean bucketKeyEnabled) {
+        @Nullable Boolean bucketKeyEnabled,
+        @Nullable String customerAlgorithm,
+        @Nullable String customerKeyMD5) {
 
     /** What S3 applies to an object whose write asked for nothing. */
     public static final String DEFAULT_ALGORITHM = "AES256";
+
+    /** The algorithm value that names a KMS key rather than S3's own. */
+    public static final String KMS_ALGORITHM = "aws:kms";
 
     /**
      * What a write request's encryption fields come to rest as.  A request
@@ -42,14 +53,27 @@ public record Encryption(
             @Nullable String kmsKeyId, @Nullable String kmsContext,
             @Nullable Boolean bucketKeyEnabled) {
         return algorithm == null ?
-                new Encryption(DEFAULT_ALGORITHM, null, null, null) :
+                new Encryption(DEFAULT_ALGORITHM, null, null, null, null,
+                        null) :
                 new Encryption(algorithm, kmsKeyId, kmsContext,
-                        bucketKeyEnabled);
+                        bucketKeyEnabled, null, null);
+    }
+
+    /**
+     * An object resting under a key its caller holds.  The MD5 is all a
+     * store may keep of it: enough to recognize the key when a read
+     * presents it again, and no more than S3 itself echoes on responses.
+     */
+    public static Encryption forCustomerKey(String customerAlgorithm,
+            String customerKeyMD5) {
+        return new Encryption(null, null, null, null, customerAlgorithm,
+                customerKeyMD5);
     }
 
     /** Whether this is the default every unasked-for object rests under. */
     public boolean isDefault() {
         return DEFAULT_ALGORITHM.equals(algorithm) && kmsKeyId == null &&
-                kmsContext == null && bucketKeyEnabled == null;
+                kmsContext == null && bucketKeyEnabled == null &&
+                customerKeyMD5 == null;
     }
 }

--- a/src/main/java/org/gaul/s3proxy/gcloudsdk/GCloudBlobStore.java
+++ b/src/main/java/org/gaul/s3proxy/gcloudsdk/GCloudBlobStore.java
@@ -63,7 +63,6 @@ import com.google.cloud.storage.StorageOptions;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import com.google.common.hash.HashCode;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
 import com.google.common.hash.HashingInputStream;
@@ -109,6 +108,7 @@ import software.amazon.awssdk.services.s3.model.S3Object;
 import software.amazon.awssdk.services.s3.model.StorageClass;
 import software.amazon.awssdk.services.s3.model.UploadPartCopyRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartCopyResponse;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 
 public final class GCloudBlobStore implements BlobStore {
@@ -1255,8 +1255,10 @@ public final class GCloudBlobStore implements BlobStore {
 
     @Override
     public UploadPartResponse uploadMultipartPart(MultipartUpload mpu,
-            int partNumber, InputStream is, long contentLength,
-            @Nullable HashCode contentMD5) {
+            UploadPartRequest request, InputStream is) {
+        int partNumber = request.partNumber();
+        long contentLength = request.contentLength();
+        var contentMD5 = SdkRequests.contentMD5(request);
         if (partNumber < 1 || partNumber > 10_000) {
             throw new IllegalArgumentException(
                     "Part number must be between 1 and 10,000, got: " +

--- a/src/main/java/org/gaul/s3proxy/nio2blob/AbstractNio2BlobStore.java
+++ b/src/main/java/org/gaul/s3proxy/nio2blob/AbstractNio2BlobStore.java
@@ -68,6 +68,7 @@ import com.google.common.primitives.Longs;
 
 import org.gaul.s3proxy.blobstore.BlobStore;
 import org.gaul.s3proxy.blobstore.ContentMetadata;
+import org.gaul.s3proxy.blobstore.CustomerKeys;
 import org.gaul.s3proxy.blobstore.S3Exceptions;
 import org.gaul.s3proxy.blobstore.SdkRequests;
 import org.gaul.s3proxy.blobstore.SdkResponses;
@@ -114,6 +115,7 @@ import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.model.S3Object;
 import software.amazon.awssdk.services.s3.model.StorageClass;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 
 public abstract class AbstractNio2BlobStore implements BlobStore {
@@ -167,6 +169,12 @@ public abstract class AbstractNio2BlobStore implements BlobStore {
     private static final String XATTR_SSE_KMS_CONTEXT = "user.sse-kms-context";
     private static final String XATTR_SSE_BUCKET_KEY =
             "user.sse-bucket-key-enabled";
+    // A customer-key object keeps the key's MD5 and never the key: enough
+    // to recognize the key when a later request presents it, and no more
+    // than S3 itself echoes on responses.
+    private static final String XATTR_SSE_C_ALGORITHM =
+            "user.sse-c-algorithm";
+    private static final String XATTR_SSE_C_KEY_MD5 = "user.sse-c-key-md5";
     /** The version id every write to an unversioned container carries. */
     private static final String NULL_VERSION_ID = "null";
     private static final int UUID_STRING_LENGTH =
@@ -842,7 +850,9 @@ public abstract class AbstractNio2BlobStore implements BlobStore {
         checkNotReserved(request.key());
         var encryption = requestEncryption(
                 request.serverSideEncryptionAsString(), request.ssekmsKeyId(),
-                request.ssekmsEncryptionContext(), request.bucketKeyEnabled());
+                request.ssekmsEncryptionContext(), request.bucketKeyEnabled(),
+                request.sseCustomerAlgorithm(), request.sseCustomerKey(),
+                request.sseCustomerKeyMD5());
         var result = putBlob(request.bucket(),
                 toBlobBuilder(request).encryption(encryption).payload(payload)
                         .build(),
@@ -859,6 +869,10 @@ public abstract class AbstractNio2BlobStore implements BlobStore {
                         encryption.kmsContext())
                 .bucketKeyEnabled(encryption == null ? null :
                         encryption.bucketKeyEnabled())
+                .sseCustomerAlgorithm(encryption == null ? null :
+                        encryption.customerAlgorithm())
+                .sseCustomerKeyMD5(encryption == null ? null :
+                        encryption.customerKeyMD5())
                 .build();
     }
 
@@ -1157,6 +1171,15 @@ public abstract class AbstractNio2BlobStore implements BlobStore {
         // failing check still closes the file InputStream returned by
         // getBlob.
         try (var is = requireNonNull(blob.getPayload())) {
+            // Reading the source is a read like any other: it answers only
+            // to the key it rests under, presented in the copy-source
+            // variants of the customer-key headers.
+            var sourceEncryption = blob.getMetadata().encryption();
+            CustomerKeys.enforce(sourceEncryption == null ? null :
+                            sourceEncryption.customerKeyMD5(),
+                    request.copySourceSSECustomerAlgorithm(),
+                    request.copySourceSSECustomerKey(),
+                    request.copySourceSSECustomerKeyMD5());
             var eTag = blob.getMetadata().eTag();
             String ifMatch = request.copySourceIfMatch();
             String ifNoneMatch = request.copySourceIfNoneMatch();
@@ -1229,7 +1252,10 @@ public abstract class AbstractNio2BlobStore implements BlobStore {
             var encryption = requestEncryption(
                     request.serverSideEncryptionAsString(),
                     request.ssekmsKeyId(), request.ssekmsEncryptionContext(),
-                    request.bucketKeyEnabled());
+                    request.bucketKeyEnabled(),
+                    request.sseCustomerAlgorithm(),
+                    request.sseCustomerKey(),
+                    request.sseCustomerKeyMD5());
             var result = putBlob(toContainer,
                     builder.encryption(encryption).build(),
                     SdkRequests.aclOrPrivate(request.acl()),
@@ -1250,6 +1276,10 @@ public abstract class AbstractNio2BlobStore implements BlobStore {
                             encryption.kmsContext())
                     .bucketKeyEnabled(encryption == null ? null :
                             encryption.bucketKeyEnabled())
+                    .sseCustomerAlgorithm(encryption == null ? null :
+                            encryption.customerAlgorithm())
+                    .sseCustomerKeyMD5(encryption == null ? null :
+                            encryption.customerKeyMD5())
                     .build();
         } catch (IOException ioe) {
             throw new RuntimeException(ioe);
@@ -1879,7 +1909,9 @@ public abstract class AbstractNio2BlobStore implements BlobStore {
         // outlive the create; the stub is where the upload keeps it.
         var encryption = requestEncryption(
                 request.serverSideEncryptionAsString(), request.ssekmsKeyId(),
-                request.ssekmsEncryptionContext(), request.bucketKeyEnabled());
+                request.ssekmsEncryptionContext(), request.bucketKeyEnabled(),
+                request.sseCustomerAlgorithm(), request.sseCustomerKey(),
+                request.sseCustomerKeyMD5());
         // create a stub blob
         var blob = Blob.builder(MULTIPART_PREFIX + uploadId + "-" + request.key() + "-stub").payload(ByteSource.empty()).encryption(encryption).build();
         putBlob(request.bucket(), blob, ObjectCannedACL.PRIVATE,
@@ -1895,6 +1927,10 @@ public abstract class AbstractNio2BlobStore implements BlobStore {
                                 .ssekmsEncryptionContext(
                                         encryption.kmsContext())
                                 .bucketKeyEnabled(encryption.bucketKeyEnabled())
+                                .sseCustomerAlgorithm(
+                                        encryption.customerAlgorithm())
+                                .sseCustomerKeyMD5(
+                                        encryption.customerKeyMD5())
                                 .build());
     }
 
@@ -1995,8 +2031,11 @@ public abstract class AbstractNio2BlobStore implements BlobStore {
         }
         // The assembled object rests under what the upload was created
         // under, which the stub has carried since; this request's carrier
-        // names only the bucket and key.
+        // names only the bucket and key.  The completion must present the
+        // create-time customer key again, as every part did.
         var encryption = uploadEncryption(mpu);
+        enforceUploadCustomerKey(encryption, request.sseCustomerAlgorithm(),
+                request.sseCustomerKey(), request.sseCustomerKeyMD5());
         blobBuilder.encryption(encryption);
 
         // Publishing the assembled object is the write the condition applies
@@ -2042,17 +2081,21 @@ public abstract class AbstractNio2BlobStore implements BlobStore {
     }
 
     @Override
-    public final UploadPartResponse uploadMultipartPart(MultipartUpload mpu, int partNumber, InputStream is, long contentLength, @Nullable HashCode contentMD5) {
-        var partName = multipartPartName(mpu.id(), mpu.blobName(), partNumber);
+    public final UploadPartResponse uploadMultipartPart(MultipartUpload mpu, UploadPartRequest request, InputStream is) {
+        // Judge the part's key against the upload's before taking the
+        // bytes, the way the create-time request was judged.
+        var encryption = uploadEncryption(mpu);
+        enforceUploadCustomerKey(encryption, request.sseCustomerAlgorithm(),
+                request.sseCustomerKey(), request.sseCustomerKeyMD5());
+        var partName = multipartPartName(mpu.id(), mpu.blobName(), request.partNumber());
         var blob = Blob.builder(partName)
                 .payload(is)
-                .contentLength(contentLength)
-                .contentMD5(contentMD5)
+                .contentLength(requireNonNull(request.contentLength()))
+                .contentMD5(SdkRequests.contentMD5(request))
                 .build();
         var partETag = putBlob(mpu.containerName(), blob,
                 ObjectCannedACL.PRIVATE, /*ifNoneMatch=*/ null, /*parts=*/ null)
                 .eTag();
-        var encryption = uploadEncryption(mpu);
         if (encryption == null) {
             return SdkResponses.uploadedPart(partETag);
         }
@@ -2061,6 +2104,8 @@ public abstract class AbstractNio2BlobStore implements BlobStore {
                 .serverSideEncryption(encryption.algorithm())
                 .ssekmsKeyId(encryption.kmsKeyId())
                 .bucketKeyEnabled(encryption.bucketKeyEnabled())
+                .sseCustomerAlgorithm(encryption.customerAlgorithm())
+                .sseCustomerKeyMD5(encryption.customerKeyMD5())
                 .build();
     }
 
@@ -2340,14 +2385,86 @@ public abstract class AbstractNio2BlobStore implements BlobStore {
     /**
      * What a write request's encryption fields come to rest as, or null
      * where this store does not encrypt -- there the frontend has refused
-     * anything naming them, so the request carries none to record.
+     * anything naming them, so the request carries none to record.  A
+     * request naming a customer key is vetted here, since this store is
+     * the backend that judges it.
      */
     @Nullable
     private Encryption requestEncryption(@Nullable String algorithm,
             @Nullable String kmsKeyId, @Nullable String kmsContext,
-            @Nullable Boolean bucketKeyEnabled) {
-        return supportsServerSideEncryption() ? Encryption.forRequest(
-                algorithm, kmsKeyId, kmsContext, bucketKeyEnabled) : null;
+            @Nullable Boolean bucketKeyEnabled,
+            @Nullable String customerAlgorithm, @Nullable String customerKey,
+            @Nullable String customerKeyMD5) {
+        if (!supportsServerSideEncryption()) {
+            return null;
+        }
+        if (customerAlgorithm != null || customerKey != null ||
+                customerKeyMD5 != null) {
+            if (algorithm != null) {
+                throw S3Exceptions.invalidArgument("Server side encryption" +
+                        " specified with both SSE-C and SSE-S3 headers.");
+            }
+            return CustomerKeys.vet(customerAlgorithm, customerKey,
+                    customerKeyMD5);
+        }
+        // Judge the SSE-S3/KMS fields against each other the way S3 does:
+        // a KMS key makes sense only under aws:kms, and aws:kms names a
+        // key or nothing at all.
+        if (Encryption.KMS_ALGORITHM.equals(algorithm)) {
+            if (kmsKeyId == null) {
+                throw S3Exceptions.invalidArgument("Server side encryption" +
+                        " with aws:kms requires" +
+                        " x-amz-server-side-encryption-aws-kms-key-id.");
+            }
+        } else {
+            if (algorithm != null &&
+                    !Encryption.DEFAULT_ALGORITHM.equals(algorithm)) {
+                throw S3Exceptions.invalidArgument("The encryption" +
+                        " algorithm specified is not valid.");
+            }
+            if (kmsKeyId != null || kmsContext != null) {
+                throw S3Exceptions.invalidArgument("A KMS key or context" +
+                        " requires x-amz-server-side-encryption: aws:kms.");
+            }
+        }
+        return Encryption.forRequest(algorithm, kmsKeyId, kmsContext,
+                bucketKeyEnabled);
+    }
+
+    /**
+     * Judges an upload's later requests -- each part, and the completion
+     * -- against the key the upload was created under.  S3 requires the
+     * create-time key presented again on every one and answers 400 to
+     * anything else.
+     */
+    private static void enforceUploadCustomerKey(
+            @Nullable Encryption uploadEncryption,
+            @Nullable String customerAlgorithm, @Nullable String customerKey,
+            @Nullable String customerKeyMD5) {
+        String storedKeyMD5 = uploadEncryption == null ? null :
+                uploadEncryption.customerKeyMD5();
+        if (storedKeyMD5 == null) {
+            if (customerAlgorithm != null || customerKey != null ||
+                    customerKeyMD5 != null) {
+                throw S3Exceptions.invalidRequest("The encryption" +
+                        " parameters are not applicable to this upload.");
+            }
+            return;
+        }
+        if (customerAlgorithm == null && customerKey == null &&
+                customerKeyMD5 == null) {
+            throw S3Exceptions.invalidRequest("The multipart upload was" +
+                    " created using a form of Server Side Encryption.  The" +
+                    " correct parameters must be provided.");
+        }
+        var presented = CustomerKeys.vet(customerAlgorithm, customerKey,
+                customerKeyMD5);
+        if (!CustomerKeys.matches(storedKeyMD5,
+                presented.customerKeyMD5())) {
+            throw S3Exceptions.invalidArgument("The provided customer key" +
+                    " does not match the key the multipart upload was" +
+                    " created with.");
+        }
     }
 
     /**
@@ -2367,6 +2484,15 @@ public abstract class AbstractNio2BlobStore implements BlobStore {
         if (view == null) {
             return Encryption.forRequest(null, null, null, null);
         }
+        var customerKeyMD5 = readStringAttributeIfPresent(view, attributes,
+                XATTR_SSE_C_KEY_MD5);
+        if (customerKeyMD5 != null) {
+            var customerAlgorithm = readStringAttributeIfPresent(view,
+                    attributes, XATTR_SSE_C_ALGORITHM);
+            return Encryption.forCustomerKey(customerAlgorithm == null ?
+                    Encryption.DEFAULT_ALGORITHM : customerAlgorithm,
+                    customerKeyMD5);
+        }
         var bucketKey = readStringAttributeIfPresent(view, attributes,
                 XATTR_SSE_BUCKET_KEY);
         var algorithm = readStringAttributeIfPresent(view, attributes,
@@ -2377,7 +2503,8 @@ public abstract class AbstractNio2BlobStore implements BlobStore {
                         XATTR_SSE_KMS_KEY_ID),
                 readStringAttributeIfPresent(view, attributes,
                         XATTR_SSE_KMS_CONTEXT),
-                bucketKey == null ? null : Boolean.valueOf(bucketKey));
+                bucketKey == null ? null : Boolean.valueOf(bucketKey),
+                /*customerAlgorithm=*/ null, /*customerKeyMD5=*/ null);
     }
 
     /**
@@ -2399,6 +2526,10 @@ public abstract class AbstractNio2BlobStore implements BlobStore {
         writeStringAttributeIfPresent(view, XATTR_SSE_BUCKET_KEY,
                 encryption.bucketKeyEnabled() == null ? null :
                         encryption.bucketKeyEnabled().toString());
+        writeStringAttributeIfPresent(view, XATTR_SSE_C_ALGORITHM,
+                encryption.customerAlgorithm());
+        writeStringAttributeIfPresent(view, XATTR_SSE_C_KEY_MD5,
+                encryption.customerKeyMD5());
     }
 
     // TODO: call in other places

--- a/src/main/java/org/gaul/s3proxy/openstackswift/OpenStackSwiftBlobStore.java
+++ b/src/main/java/org/gaul/s3proxy/openstackswift/OpenStackSwiftBlobStore.java
@@ -56,6 +56,7 @@ import com.google.common.net.HttpHeaders;
 import org.gaul.s3proxy.blobstore.BlobStore;
 import org.gaul.s3proxy.blobstore.Credentials;
 import org.gaul.s3proxy.blobstore.S3Exceptions;
+import org.gaul.s3proxy.blobstore.SdkRequests;
 import org.gaul.s3proxy.blobstore.SdkResponses;
 import org.gaul.s3proxy.blobstore.domain.Blob;
 import org.gaul.s3proxy.blobstore.domain.MultipartUpload;
@@ -110,6 +111,7 @@ import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.model.S3Object;
 import software.amazon.awssdk.services.s3.model.StorageClass;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 
 /**
@@ -1249,12 +1251,12 @@ public final class OpenStackSwiftBlobStore implements BlobStore {
 
     @Override
     public UploadPartResponse uploadMultipartPart(MultipartUpload mpu,
-            int partNumber, InputStream is, long contentLength,
-            @Nullable HashCode contentMD5) {
-        var segment = Blob.builder(mpuSegmentKey(mpu.id(), partNumber))
+            UploadPartRequest request, InputStream is) {
+        var segment = Blob.builder(
+                mpuSegmentKey(mpu.id(), request.partNumber()))
                 .payload(is)
-                .contentLength(contentLength)
-                .contentMD5(contentMD5)
+                .contentLength(request.contentLength())
+                .contentMD5(SdkRequests.contentMD5(request))
                 .build();
         String eTag = putBlobInternal(mpu.containerName(), segment,
                 /*ifNoneMatch=*/ null).eTag();

--- a/src/test/java/org/gaul/s3proxy/AliasBlobStoreTest.java
+++ b/src/test/java/org/gaul/s3proxy/AliasBlobStoreTest.java
@@ -129,8 +129,8 @@ public final class AliasBlobStoreTest {
         MultipartUpload mpu = aliasBlobStore.initiateMultipartUpload(
                 TestUtils.createRequest(aliasContainerName, blobName));
         assertThat(mpu.containerName()).isEqualTo(aliasContainerName);
-        var part = aliasBlobStore.uploadMultipartPart(
-                mpu, 1, content.openStream(), content.size(), null);
+        var part = TestUtils.uploadPart(aliasBlobStore,
+                mpu, 1, content.openStream(), content.size());
         assertThat(part.eTag()).isEqualTo(contentHash.toString());
         String mpuETag = aliasBlobStore.completeMultipartUpload(mpu,
                 SdkRequests.completeRequest(mpu,
@@ -172,8 +172,8 @@ public final class AliasBlobStoreTest {
         ByteSource content = TestUtils.randomByteSource().slice(0, 1024);
         MultipartUpload mpu = aliasBlobStore.initiateMultipartUpload(
                 TestUtils.createRequest(aliasContainerName, blobName));
-        aliasBlobStore.uploadMultipartPart(
-                mpu, 1, content.openStream(), content.size(), null);
+        TestUtils.uploadPart(aliasBlobStore,
+                mpu, 1, content.openStream(), content.size());
 
         var parts = aliasBlobStore.listMultipartUpload(mpu);
         assertThat(parts).hasSize(1);

--- a/src/test/java/org/gaul/s3proxy/EncryptedBlobStoreTest.java
+++ b/src/test/java/org/gaul/s3proxy/EncryptedBlobStoreTest.java
@@ -108,8 +108,8 @@ public final class EncryptedBlobStoreTest {
         int partNumber = 1;
         for (String part : new String[] {MPU_PART1, MPU_PART2, MPU_PART3}) {
             byte[] bytes = part.getBytes(StandardCharsets.UTF_8);
-            encryptedBlobStore.uploadMultipartPart(mpu, partNumber++,
-                new ByteArrayInputStream(bytes), bytes.length, null);
+            TestUtils.uploadPart(encryptedBlobStore, mpu, partNumber++,
+                new ByteArrayInputStream(bytes), bytes.length);
         }
 
         encryptedBlobStore.completeMultipartUpload(mpu,
@@ -337,12 +337,12 @@ public final class EncryptedBlobStoreTest {
         byte[] bytes2 = contentParts[1].getBytes(StandardCharsets.UTF_8);
         byte[] bytes3 = contentParts[2].getBytes(StandardCharsets.UTF_8);
 
-        encryptedBlobStore.uploadMultipartPart(mpu, 1,
-            new ByteArrayInputStream(bytes1), bytes1.length, null);
-        encryptedBlobStore.uploadMultipartPart(mpu, 2,
-            new ByteArrayInputStream(bytes2), bytes2.length, null);
-        encryptedBlobStore.uploadMultipartPart(mpu, 3,
-            new ByteArrayInputStream(bytes3), bytes3.length, null);
+        TestUtils.uploadPart(encryptedBlobStore, mpu, 1,
+            new ByteArrayInputStream(bytes1), bytes1.length);
+        TestUtils.uploadPart(encryptedBlobStore, mpu, 2,
+            new ByteArrayInputStream(bytes2), bytes2.length);
+        TestUtils.uploadPart(encryptedBlobStore, mpu, 3,
+            new ByteArrayInputStream(bytes3), bytes3.length);
 
         var parts = encryptedBlobStore.listMultipartUpload(mpu);
 
@@ -383,8 +383,8 @@ public final class EncryptedBlobStoreTest {
         MultipartUpload mpu = encryptedBlobStore.initiateMultipartUpload(
             TestUtils.createRequest(containerName, blobName));
         byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
-        var uploaded = encryptedBlobStore.uploadMultipartPart(mpu, 1,
-            new ByteArrayInputStream(bytes), bytes.length, null);
+        var uploaded = TestUtils.uploadPart(encryptedBlobStore, mpu, 1,
+            new ByteArrayInputStream(bytes), bytes.length);
         var completeRequest = SdkRequests.completeRequest(mpu,
             List.of(TestUtils.completedPart(1, uploaded)));
 
@@ -633,12 +633,12 @@ public final class EncryptedBlobStoreTest {
         byte[] bytes2 = content2.getBytes(StandardCharsets.UTF_8);
         byte[] bytes3 = content3.getBytes(StandardCharsets.UTF_8);
 
-        encryptedBlobStore.uploadMultipartPart(mpu, 1,
-            new ByteArrayInputStream(bytes1), bytes1.length, null);
-        encryptedBlobStore.uploadMultipartPart(mpu, 2,
-            new ByteArrayInputStream(bytes2), bytes2.length, null);
-        encryptedBlobStore.uploadMultipartPart(mpu, 3,
-            new ByteArrayInputStream(bytes3), bytes3.length, null);
+        TestUtils.uploadPart(encryptedBlobStore, mpu, 1,
+            new ByteArrayInputStream(bytes1), bytes1.length);
+        TestUtils.uploadPart(encryptedBlobStore, mpu, 2,
+            new ByteArrayInputStream(bytes2), bytes2.length);
+        TestUtils.uploadPart(encryptedBlobStore, mpu, 3,
+            new ByteArrayInputStream(bytes3), bytes3.length);
 
         var mpus =
             encryptedBlobStore.listMultipartUploads(containerName);

--- a/src/test/java/org/gaul/s3proxy/EventualBlobStoreTest.java
+++ b/src/test/java/org/gaul/s3proxy/EventualBlobStoreTest.java
@@ -152,9 +152,9 @@ public final class EventualBlobStoreTest {
                         .contentType(MediaType.MP4_AUDIO.toString())
                         .metadata(Map.of("key", "value"))
                         .build());
-        var part = eventualBlobStore.uploadMultipartPart(mpu,
+        var part = TestUtils.uploadPart(eventualBlobStore, mpu,
                 /*partNumber=*/ 1, BYTE_SOURCE.openStream(),
-                BYTE_SOURCE.size(), null);
+                BYTE_SOURCE.size());
         eventualBlobStore.completeMultipartUpload(mpu,
                 SdkRequests.completeRequest(mpu,
                         List.of(TestUtils.completedPart(1, part))));

--- a/src/test/java/org/gaul/s3proxy/NullBlobStoreTest.java
+++ b/src/test/java/org/gaul/s3proxy/NullBlobStoreTest.java
@@ -159,10 +159,10 @@ public final class NullBlobStoreTest {
                 0, nullBlobStore.getMinimumMultipartPartSize());
         ByteSource byteSource2 = byteSource.slice(
                 nullBlobStore.getMinimumMultipartPartSize(), 1);
-        var part1 = nullBlobStore.uploadMultipartPart(mpu, 1,
-                byteSource1.openStream(), byteSource1.size(), null);
-        var part2 = nullBlobStore.uploadMultipartPart(mpu, 2,
-                byteSource2.openStream(), byteSource2.size(), null);
+        var part1 = TestUtils.uploadPart(nullBlobStore, mpu, 1,
+                byteSource1.openStream(), byteSource1.size());
+        var part2 = TestUtils.uploadPart(nullBlobStore, mpu, 2,
+                byteSource2.openStream(), byteSource2.size());
 
         var parts = nullBlobStore.listMultipartUpload(mpu);
         assertThat(parts.get(0).partNumber()).isEqualTo(1);
@@ -211,10 +211,10 @@ public final class NullBlobStoreTest {
                 0, nullBlobStore.getMinimumMultipartPartSize());
         ByteSource byteSource2 = byteSource.slice(
                 nullBlobStore.getMinimumMultipartPartSize(), 1);
-        nullBlobStore.uploadMultipartPart(initiated, 1,
-                byteSource1.openStream(), byteSource1.size(), null);
-        nullBlobStore.uploadMultipartPart(initiated, 2,
-                byteSource2.openStream(), byteSource2.size(), null);
+        TestUtils.uploadPart(nullBlobStore, initiated, 1,
+                byteSource1.openStream(), byteSource1.size());
+        TestUtils.uploadPart(nullBlobStore, initiated, 2,
+                byteSource2.openStream(), byteSource2.size());
         var parts = nullBlobStore.listMultipartUpload(
                 initiated);
 

--- a/src/test/java/org/gaul/s3proxy/PrefixBlobStoreTest.java
+++ b/src/test/java/org/gaul/s3proxy/PrefixBlobStoreTest.java
@@ -125,8 +125,8 @@ public final class PrefixBlobStoreTest {
         assertThat(mpu.containerName()).isEqualTo(containerName);
         assertThat(mpu.blobName()).isEqualTo("archive.bin");
 
-        var part = prefixBlobStore.uploadMultipartPart(
-                mpu, 1, content.openStream(), content.size(), null);
+        var part = TestUtils.uploadPart(prefixBlobStore,
+                mpu, 1, content.openStream(), content.size());
         prefixBlobStore.completeMultipartUpload(mpu,
                 SdkRequests.completeRequest(mpu,
                         List.of(TestUtils.completedPart(1, part))));

--- a/src/test/java/org/gaul/s3proxy/RemoveBlobsTest.java
+++ b/src/test/java/org/gaul/s3proxy/RemoveBlobsTest.java
@@ -30,7 +30,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.hash.HashCode;
 
 import org.gaul.s3proxy.blobstore.BlobStore;
 import org.gaul.s3proxy.blobstore.domain.MultipartUpload;
@@ -64,6 +63,7 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 import software.amazon.awssdk.services.s3.model.S3Error;
 import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 
 /**
@@ -408,8 +408,7 @@ public final class RemoveBlobsTest {
 
         @Override
         public UploadPartResponse uploadMultipartPart(MultipartUpload mpu,
-                int partNumber, InputStream payload, long contentLength,
-                @Nullable HashCode contentMD5) {
+                UploadPartRequest request, InputStream payload) {
             throw new UnsupportedOperationException();
         }
 

--- a/src/test/java/org/gaul/s3proxy/ServerSideEncryptionTest.java
+++ b/src/test/java/org/gaul/s3proxy/ServerSideEncryptionTest.java
@@ -65,6 +65,13 @@ public final class ServerSideEncryptionTest {
     private static final String KMS_CONTEXT = Base64.getEncoder()
             .encodeToString("{\"purpose\":\"testing\"}"
                     .getBytes(StandardCharsets.UTF_8));
+    /** Two customer keys, alike in everything but their bytes. */
+    private static final byte[] KEY_A =
+            "0123456789abcdef0123456789abcdef"
+                    .getBytes(StandardCharsets.UTF_8);
+    private static final byte[] KEY_B =
+            "fedcba9876543210fedcba9876543210"
+                    .getBytes(StandardCharsets.UTF_8);
 
     @TempDir
     private Path root;
@@ -317,6 +324,17 @@ public final class ServerSideEncryptionTest {
                 HttpResponse.BodyHandlers.ofString());
         assertThat(response.statusCode()).isEqualTo(501);
 
+        // The customer-key family is refused the same way: silently
+        // dropping it would read around a key the caller presented.
+        response = HttpClient.newHttpClient().send(
+                HttpRequest.newBuilder(uri)
+                        .header("x-amz-server-side-encryption-customer-" +
+                                "algorithm", "AES256")
+                        .GET()
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+        assertThat(response.statusCode()).isEqualTo(501);
+
         response = HttpClient.newHttpClient().send(
                 HttpRequest.newBuilder(uri).GET().build(),
                 HttpResponse.BodyHandlers.ofString());
@@ -324,27 +342,280 @@ public final class ServerSideEncryptionTest {
     }
 
     @Test
-    @SuppressWarnings("deprecation")
-    public void testCustomerKeysStayRefused() throws Exception {
-        // SSE-C stays out even on a store that encrypts: dropping the
-        // caller's key would claim an encryption nobody performed.
-        startEncrypting();
+    public void testCustomerKeysRefusedWhereBackendCannot() throws Exception {
+        startRefusing();
 
-        byte[] key = "0123456789abcdef0123456789abcdef"
-                .getBytes(StandardCharsets.UTF_8);
         assertRefused(() -> client.putObject(
                 b -> b.bucket(containerName).key("blob")
                         .sseCustomerAlgorithm("AES256")
-                        .sseCustomerKey(Base64.getEncoder()
-                                .encodeToString(key))
-                        .sseCustomerKeyMD5(Base64.getEncoder().encodeToString(
-                                Hashing.md5().hashBytes(key).asBytes())),
+                        .sseCustomerKey(encodeKey(KEY_A))
+                        .sseCustomerKeyMD5(keyMD5(KEY_A)),
                 RequestBody.fromString("payload")));
     }
 
+    @Test
+    public void testCustomerKeyRoundTrip() throws Exception {
+        startEncrypting();
+
+        // The object rests under the caller's key and reports the key's
+        // MD5 rather than an algorithm in x-amz-server-side-encryption:
+        // SSE-C and SSE-S3 exclude each other on responses as on requests.
+        var put = client.putObject(
+                b -> b.bucket(containerName).key("blob")
+                        .sseCustomerAlgorithm("AES256")
+                        .sseCustomerKey(encodeKey(KEY_A))
+                        .sseCustomerKeyMD5(keyMD5(KEY_A)),
+                RequestBody.fromString("payload"));
+        assertThat(put.serverSideEncryption()).isNull();
+        assertThat(put.sseCustomerAlgorithm()).isEqualTo("AES256");
+        assertThat(put.sseCustomerKeyMD5()).isEqualTo(keyMD5(KEY_A));
+
+        var head = client.headObject(
+                b -> b.bucket(containerName).key("blob")
+                        .sseCustomerAlgorithm("AES256")
+                        .sseCustomerKey(encodeKey(KEY_A))
+                        .sseCustomerKeyMD5(keyMD5(KEY_A)));
+        assertThat(head.serverSideEncryption()).isNull();
+        assertThat(head.sseCustomerAlgorithm()).isEqualTo("AES256");
+        assertThat(head.sseCustomerKeyMD5()).isEqualTo(keyMD5(KEY_A));
+
+        var get = client.getObjectAsBytes(
+                b -> b.bucket(containerName).key("blob")
+                        .sseCustomerAlgorithm("AES256")
+                        .sseCustomerKey(encodeKey(KEY_A))
+                        .sseCustomerKeyMD5(keyMD5(KEY_A)));
+        assertThat(get.response().serverSideEncryption()).isNull();
+        assertThat(get.response().sseCustomerAlgorithm())
+                .isEqualTo("AES256");
+        assertThat(get.response().sseCustomerKeyMD5())
+                .isEqualTo(keyMD5(KEY_A));
+        assertThat(get.asUtf8String()).isEqualTo("payload");
+    }
+
+    @Test
+    public void testCustomerKeyAnswersOnlyToItself() throws Exception {
+        startEncrypting();
+        client.putObject(b -> b.bucket(containerName).key("blob")
+                        .sseCustomerAlgorithm("AES256")
+                        .sseCustomerKey(encodeKey(KEY_A))
+                        .sseCustomerKeyMD5(keyMD5(KEY_A)),
+                RequestBody.fromString("payload"));
+
+        // Reading without the key is a request the object cannot answer,
+        // and reading with another key is one it must not.
+        assertStatus(400, () -> client.getObjectAsBytes(
+                b -> b.bucket(containerName).key("blob")));
+        assertStatus(400, () -> client.headObject(
+                b -> b.bucket(containerName).key("blob")));
+        assertStatus(400, () -> client.getObjectAsBytes(
+                b -> b.bucket(containerName).key("blob")
+                        .sseCustomerAlgorithm("AES256")
+                        .sseCustomerKey(encodeKey(KEY_B))
+                        .sseCustomerKeyMD5(keyMD5(KEY_B))));
+
+        // An object resting under no key refuses any key offered.
+        client.putObject(b -> b.bucket(containerName).key("plain"),
+                RequestBody.fromString("payload"));
+        assertStatus(400, () -> client.getObjectAsBytes(
+                b -> b.bucket(containerName).key("plain")
+                        .sseCustomerAlgorithm("AES256")
+                        .sseCustomerKey(encodeKey(KEY_A))
+                        .sseCustomerKeyMD5(keyMD5(KEY_A))));
+    }
+
+    @Test
+    public void testCustomerKeyVetted() throws Exception {
+        startEncrypting();
+
+        // An MD5 that is not the key's.
+        assertStatus(400, () -> client.putObject(
+                b -> b.bucket(containerName).key("blob")
+                        .sseCustomerAlgorithm("AES256")
+                        .sseCustomerKey(encodeKey(KEY_A))
+                        .sseCustomerKeyMD5(keyMD5(KEY_B)),
+                RequestBody.fromString("payload")));
+        // A key shorter than 256 bits.
+        assertStatus(400, () -> client.putObject(
+                b -> b.bucket(containerName).key("blob")
+                        .sseCustomerAlgorithm("AES256")
+                        .sseCustomerKey(Base64.getEncoder().encodeToString(
+                                "short".getBytes(StandardCharsets.UTF_8)))
+                        .sseCustomerKeyMD5(keyMD5(
+                                "short".getBytes(StandardCharsets.UTF_8))),
+                RequestBody.fromString("payload")));
+        // An algorithm with no key to go with it.
+        assertStatus(400, () -> client.putObject(
+                b -> b.bucket(containerName).key("blob")
+                        .sseCustomerAlgorithm("AES256"),
+                RequestBody.fromString("payload")));
+        // Both modes at once.
+        assertStatus(400, () -> client.putObject(
+                b -> b.bucket(containerName).key("blob")
+                        .serverSideEncryption(ServerSideEncryption.AES256)
+                        .sseCustomerAlgorithm("AES256")
+                        .sseCustomerKey(encodeKey(KEY_A))
+                        .sseCustomerKeyMD5(keyMD5(KEY_A)),
+                RequestBody.fromString("payload")));
+
+        // Nothing above may have stored anything readable.
+        assertThat(client.listObjectsV2(b -> b.bucket(containerName))
+                .contents()).isEmpty();
+    }
+
+    @Test
+    public void testCustomerKeyCopy() throws Exception {
+        startEncrypting();
+        client.putObject(b -> b.bucket(containerName).key("blob")
+                        .sseCustomerAlgorithm("AES256")
+                        .sseCustomerKey(encodeKey(KEY_A))
+                        .sseCustomerKeyMD5(keyMD5(KEY_A)),
+                RequestBody.fromString("payload"));
+
+        // Reading the source needs its key; the destination rests under
+        // its own, named in the plain variants of the same headers.
+        assertStatus(400, () -> client.copyObject(b -> b
+                .sourceBucket(containerName).sourceKey("blob")
+                .destinationBucket(containerName).destinationKey("copy")));
+        assertStatus(400, () -> client.copyObject(b -> b
+                .sourceBucket(containerName).sourceKey("blob")
+                .destinationBucket(containerName).destinationKey("copy")
+                .copySourceSSECustomerAlgorithm("AES256")
+                .copySourceSSECustomerKey(encodeKey(KEY_B))
+                .copySourceSSECustomerKeyMD5(keyMD5(KEY_B))));
+
+        var copy = client.copyObject(b -> b
+                .sourceBucket(containerName).sourceKey("blob")
+                .destinationBucket(containerName).destinationKey("copy")
+                .copySourceSSECustomerAlgorithm("AES256")
+                .copySourceSSECustomerKey(encodeKey(KEY_A))
+                .copySourceSSECustomerKeyMD5(keyMD5(KEY_A))
+                .sseCustomerAlgorithm("AES256")
+                .sseCustomerKey(encodeKey(KEY_B))
+                .sseCustomerKeyMD5(keyMD5(KEY_B)));
+        assertThat(copy.sseCustomerAlgorithm()).isEqualTo("AES256");
+        assertThat(copy.sseCustomerKeyMD5()).isEqualTo(keyMD5(KEY_B));
+
+        var get = client.getObjectAsBytes(
+                b -> b.bucket(containerName).key("copy")
+                        .sseCustomerAlgorithm("AES256")
+                        .sseCustomerKey(encodeKey(KEY_B))
+                        .sseCustomerKeyMD5(keyMD5(KEY_B)));
+        assertThat(get.asUtf8String()).isEqualTo("payload");
+
+        // A copy asking for no encryption rests under the default, which
+        // any later read may have without a key.
+        client.copyObject(b -> b
+                .sourceBucket(containerName).sourceKey("blob")
+                .destinationBucket(containerName).destinationKey("decrypted")
+                .copySourceSSECustomerAlgorithm("AES256")
+                .copySourceSSECustomerKey(encodeKey(KEY_A))
+                .copySourceSSECustomerKeyMD5(keyMD5(KEY_A)));
+        assertThat(client.getObjectAsBytes(
+                b -> b.bucket(containerName).key("decrypted"))
+                .asUtf8String()).isEqualTo("payload");
+    }
+
+    @Test
+    public void testCustomerKeyMultipart() throws Exception {
+        startEncrypting();
+
+        var create = client.createMultipartUpload(
+                b -> b.bucket(containerName).key("mpu")
+                        .sseCustomerAlgorithm("AES256")
+                        .sseCustomerKey(encodeKey(KEY_A))
+                        .sseCustomerKeyMD5(keyMD5(KEY_A)));
+        assertThat(create.serverSideEncryption()).isNull();
+        assertThat(create.sseCustomerAlgorithm()).isEqualTo("AES256");
+        assertThat(create.sseCustomerKeyMD5()).isEqualTo(keyMD5(KEY_A));
+
+        // Every part must present the create-time key again, and any
+        // other request is malformed rather than merely denied.
+        assertStatus(400, () -> client.uploadPart(
+                b -> b.bucket(containerName).key("mpu")
+                        .uploadId(create.uploadId()).partNumber(1),
+                RequestBody.fromString("payload")));
+        assertStatus(400, () -> client.uploadPart(
+                b -> b.bucket(containerName).key("mpu")
+                        .uploadId(create.uploadId()).partNumber(1)
+                        .sseCustomerAlgorithm("AES256")
+                        .sseCustomerKey(encodeKey(KEY_B))
+                        .sseCustomerKeyMD5(keyMD5(KEY_B)),
+                RequestBody.fromString("payload")));
+
+        var part = client.uploadPart(
+                b -> b.bucket(containerName).key("mpu")
+                        .uploadId(create.uploadId()).partNumber(1)
+                        .sseCustomerAlgorithm("AES256")
+                        .sseCustomerKey(encodeKey(KEY_A))
+                        .sseCustomerKeyMD5(keyMD5(KEY_A)),
+                RequestBody.fromString("payload"));
+        assertThat(part.sseCustomerAlgorithm()).isEqualTo("AES256");
+        assertThat(part.sseCustomerKeyMD5()).isEqualTo(keyMD5(KEY_A));
+
+        // A part copied in needs the create-time key like an uploaded one,
+        // before any bytes move.
+        client.putObject(b -> b.bucket(containerName).key("src"),
+                RequestBody.fromString("payload"));
+        assertStatus(400, () -> client.uploadPartCopy(b -> b
+                .sourceBucket(containerName).sourceKey("src")
+                .destinationBucket(containerName).destinationKey("mpu")
+                .uploadId(create.uploadId()).partNumber(2)));
+
+        // The completion must present the create-time key again, as every
+        // part did; the object then answers only to that key.
+        assertStatus(400, () -> client.completeMultipartUpload(
+                b -> b.bucket(containerName).key("mpu")
+                        .uploadId(create.uploadId())
+                        .multipartUpload(CompletedMultipartUpload.builder()
+                                .parts(CompletedPart.builder()
+                                        .partNumber(1)
+                                        .eTag(part.eTag())
+                                        .build())
+                                .build())));
+        client.completeMultipartUpload(
+                b -> b.bucket(containerName).key("mpu")
+                        .uploadId(create.uploadId())
+                        .multipartUpload(CompletedMultipartUpload.builder()
+                                .parts(CompletedPart.builder()
+                                        .partNumber(1)
+                                        .eTag(part.eTag())
+                                        .build())
+                                .build())
+                        .sseCustomerAlgorithm("AES256")
+                        .sseCustomerKey(encodeKey(KEY_A))
+                        .sseCustomerKeyMD5(keyMD5(KEY_A)));
+
+        assertStatus(400, () -> client.getObjectAsBytes(
+                b -> b.bucket(containerName).key("mpu")));
+        var get = client.getObjectAsBytes(
+                b -> b.bucket(containerName).key("mpu")
+                        .sseCustomerAlgorithm("AES256")
+                        .sseCustomerKey(encodeKey(KEY_A))
+                        .sseCustomerKeyMD5(keyMD5(KEY_A)));
+        assertThat(get.response().sseCustomerAlgorithm())
+                .isEqualTo("AES256");
+        assertThat(get.response().sseCustomerKeyMD5())
+                .isEqualTo(keyMD5(KEY_A));
+        assertThat(get.asUtf8String()).isEqualTo("payload");
+    }
+
+    private static String encodeKey(byte[] key) {
+        return Base64.getEncoder().encodeToString(key);
+    }
+
+    @SuppressWarnings("deprecation")
+    private static String keyMD5(byte[] key) {
+        return Base64.getEncoder().encodeToString(
+                Hashing.md5().hashBytes(key).asBytes());
+    }
+
     private static void assertRefused(ThrowingCallable callable) {
+        assertStatus(501, callable);
+    }
+
+    private static void assertStatus(int status, ThrowingCallable callable) {
         assertThatThrownBy(callable)
                 .isInstanceOfSatisfying(S3Exception.class,
-                        e -> assertThat(e.statusCode()).isEqualTo(501));
+                        e -> assertThat(e.statusCode()).isEqualTo(status));
     }
 }

--- a/src/test/java/org/gaul/s3proxy/TestUtils.java
+++ b/src/test/java/org/gaul/s3proxy/TestUtils.java
@@ -115,6 +115,23 @@ final class TestUtils {
                 completedParts(parts));
     }
 
+    /** Uploads one part of {@code mpu} with a plain carrier request. */
+    static software.amazon.awssdk.services.s3.model
+            .UploadPartResponse uploadPart(BlobStore blobStore,
+            org.gaul.s3proxy.blobstore.domain.MultipartUpload mpu,
+            int partNumber, InputStream is, long contentLength) {
+        return blobStore.uploadMultipartPart(mpu,
+                software.amazon.awssdk.services.s3.model.UploadPartRequest
+                        .builder()
+                        .bucket(mpu.containerName())
+                        .key(mpu.blobName())
+                        .uploadId(mpu.id())
+                        .partNumber(partNumber)
+                        .contentLength(contentLength)
+                        .build(),
+                is);
+    }
+
     static ByteSource randomByteSource() {
         return randomByteSource(0);
     }

--- a/src/test/java/org/gaul/s3proxy/TierBlobStoreTest.java
+++ b/src/test/java/org/gaul/s3proxy/TierBlobStoreTest.java
@@ -78,8 +78,8 @@ public final class TierBlobStoreTest {
         var mpu = tierBlobStore.initiateMultipartUpload(
                 TestUtils.createRequest(containerName, blobName));
 
-        tierBlobStore.uploadMultipartPart(mpu, 1, content.openStream(),
-                content.size(), null);
+        TestUtils.uploadPart(tierBlobStore, mpu, 1, content.openStream(),
+                content.size());
 
         var parts = tierBlobStore.listMultipartUpload(mpu);
         tierBlobStore.completeMultipartUpload(mpu,
@@ -96,8 +96,8 @@ public final class TierBlobStoreTest {
         var mpu = blobStore.initiateMultipartUpload(
                 TestUtils.createRequest(containerName, blobName));
 
-        blobStore.uploadMultipartPart(mpu, 1, content.openStream(),
-                content.size(), null);
+        TestUtils.uploadPart(blobStore, mpu, 1, content.openStream(),
+                content.size());
 
         var parts = blobStore.listMultipartUpload(mpu);
         blobStore.completeMultipartUpload(mpu,

--- a/src/test/java/org/gaul/s3proxy/UserMetadataReplacerBlobStoreTest.java
+++ b/src/test/java/org/gaul/s3proxy/UserMetadataReplacerBlobStoreTest.java
@@ -159,8 +159,8 @@ public final class UserMetadataReplacerBlobStoreTest {
                 TestUtils.createRequest(containerName, blobName).toBuilder()
                         .metadata(Map.of("my-key", "my-value-"))
                         .build());
-        var part = userMetadataReplacerBlobStore.uploadMultipartPart(
-                mpu, 1, content.openStream(), content.size(), null);
+        var part = TestUtils.uploadPart(userMetadataReplacerBlobStore,
+                mpu, 1, content.openStream(), content.size());
         userMetadataReplacerBlobStore.completeMultipartUpload(mpu,
                 SdkRequests.completeRequest(mpu,
                         List.of(TestUtils.completedPart(1, part))));

--- a/src/test/resources/run-s3-tests.sh
+++ b/src/test/resources/run-s3-tests.sh
@@ -109,16 +109,14 @@ tags='not appendobject'\
 ' and not versioning'\
 ' and not webidentity_test'
 
-# Admits the SSE-S3 tests on a lane whose store encrypts.  Dropping the tag
-# is not enough on its own: eighteen of the twenty-one tests carry the
-# encryption tag as well, so the expression has to let sse_s3 back through
-# that exclusion rather than lift it.  What the encryption tag covers beyond
-# SSE-S3 stays out, being SSE-C, which s3proxy refuses everywhere by design;
-# so does bucket_encryption, whose tests ask a bucket to encrypt by default
-# -- the unimplemented ?encryption subresource rather than the header family.
-enable_sse_s3_tests() {
+# Admits the server-side encryption tests on a lane whose store encrypts:
+# the sse_s3 tag and the encryption tag whole, whose remainder beyond
+# SSE-S3 is SSE-C, answered now on the same stores.  bucket_encryption
+# stays out, its tests asking a bucket to encrypt by default -- the
+# unimplemented ?encryption subresource rather than the header families.
+enable_sse_tests() {
     tags="${tags/ and not sse_s3/}"
-    tags="${tags/ and not encryption/ and not (encryption and not sse_s3)}"
+    tags="${tags/ and not encryption/}"
     tags="${tags} and not bucket_encryption"
 }
 
@@ -144,9 +142,9 @@ elif [[ "${S3PROXY_CONF}" == s3proxy-localstack*.conf ]]; then
     # the only lane that covers the pass-through path.
     tags="${tags/ and not versioning/}"
     # The same goes for server-side encryption: LocalStack encrypts, so the
-    # SSE-S3 tests exercise the pass-through here rather than watching a
+    # SSE tests exercise the pass-through here rather than watching a
     # store that cannot encrypt refuse it.
-    enable_sse_s3_tests
+    enable_sse_tests
     # Five threads delete the same versions at once and each expects to have
     # deleted them all.  LocalStack refuses a version it no longer has, where
     # S3 counts deleting one that is already gone as a success -- so whether
@@ -169,11 +167,11 @@ elif [ "${S3PROXY_CONF}" = "s3proxy-filesystem.conf" ] ||
         # would owe its users; there the requests are still 501.
         tags="${tags/ and not versioning/}"
         # Server-side encryption parts the two stores on the same line: the
-        # transient store answers the header family, since what it holds
+        # transient store answers the header families, since what it holds
         # never rests anywhere a caller could read it, while the filesystem
         # store would be reporting AES256 over plaintext on a real disk and
         # answers 501 instead.  So these run here and not below.
-        enable_sse_s3_tests
+        enable_sse_tests
     else
         backend="nio2,filesystem"
     fi

--- a/src/test/resources/s3-tests.conf
+++ b/src/test/resources/s3-tests.conf
@@ -35,10 +35,12 @@ display_name = CustomersName@amazon.com
 access_key = local-identity
 secret_key = local-credential
 
-## The copy tests compare the key id a response reports against this value.
-## S3 answers with the key's ARN rather than the bare id it was given, and
-## LocalStack -- the only backend these tests run against, since it is the
-## only one that encrypts -- does the same, from a fixed account id.
+## The KMS tests compare the key id a response reports against these
+## values.  S3 answers with the key's ARN rather than the bare id it was
+## given, and LocalStack -- the only backend these tests run against,
+## since the other store that encrypts echoes whatever it was handed --
+## does the same, from a fixed account id.
+kms_keyid = arn:aws:kms:us-east-1:000000000000:key/testkey-1
 kms_keyid2 = arn:aws:kms:us-east-1:000000000000:key/testkey-2
 
 [s3 alt]


### PR DESCRIPTION
The last commit refused SSE-C everywhere because honoring a caller's key means carrying it on every read and copy, not echoing it back on the write that supplied it.  This carries it.  The frontend admits the customer-key triple and its copy-source variants onto requests it already builds -- put, get, head, copy, the multipart create, part and completion, the part-copy in both its native and streamed forms, and the POST form fields -- and the aws-s3 store forwards them verbatim like everything else, its service judging the values.

The transient store is its own service, so it judges.  A write vets the triple -- all three fields together, AES256, a 256-bit key, an MD5 that matches -- and the object comes to rest under the key's MD5 and never the key, which is no more than S3 itself echoes on responses.  SSE-C has an observable half SSE-S3 does not: the object answers only to its key.  A read presenting none or the wrong one is 400 -- the wrong one too, which the suite pins where AWS's documentation suggests 403 -- and every later request of a multipart upload, each part and the completion alike, must present the create-time key again.  The completion response echoes the algorithm and MD5 from the request it judged, the SDK's response type modeling no field for them.

Reads are judged in the frontend rather than the store, whose getBlob and blobMetadata also serve the frontend's own bookkeeping -- the stub consulted before a completion, the ETag before a conditional write -- which reads without a key the way S3's own internals do.  The stores vet what is always a caller's act: writes, parts, and the copy's source, read inside copyBlob.  What both judge the same way lives in CustomerKeys.

uploadMultipartPart takes the SDK's UploadPartRequest now, the one call whose carrier had no room for a part's key, presented again on every part as S3 requires.  The aws-s3 store forwarding the request instead of rebuilding it also stops dropping the Content-MD5 a part arrived with.

The encryption tag admitted whole brings the SSE-KMS conformance tests with it, and they found two holes beside SSE-C.  The frontend refuses what is malformed wherever it lands -- an algorithm S3 does not have, a KMS key under an algorithm that does not name one -- because LocalStack accepts both and the pass-through lane has to answer as S3 does; and it refuses the write-side family on GET and HEAD, where an object's encryption is reported, not asked for.  The transient store further requires a key id with aws:kms, the way rgw does.  kms_keyid becomes an ARN in the lane config for the same reason kms_keyid2 already was: that is what a response carries.

Both lanes whose store encrypts run the full tag now and pass -- 659 tests on the transient store, 658 through LocalStack -- and the filesystem lane still refuses the family whole, 501 on every header of it, reporting no encryption it does not perform.  Unlike S3, S3Proxy accepts SSE-C over plain HTTP, its TLS commonly terminating elsewhere.

See #402.