### PR TITLE
Version objects on azureblob

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Some limitations depend on the storage backend:
 | `max-keys=0` not honored | `azureblob` |
 | `UploadPartCopy` streams the data through S3Proxy instead of copying it on the backend | `filesystem`, `transient`, `openstack-swift`, `sftp` |
 | conditional PUT refuses `If-Match`, honoring only `If-None-Match: *` | `openstack-swift` |
-| no object versioning, see [#1137](https://github.com/gaul/s3proxy/issues/1137) | `azureblob` |
+| object versioning is opt-in and needs the account versioned out of band; no delete markers or per-bucket suspend, see [#1137](https://github.com/gaul/s3proxy/issues/1137) | `azureblob` |
 | no object versioning, see [#1138](https://github.com/gaul/s3proxy/issues/1138) | `filesystem` |
 | no object versioning, for want of a service analog | `openstack-swift`, `sftp` |
 | no server-side encryption, see [#1134](https://github.com/gaul/s3proxy/issues/1134) | `google-cloud-storage` |
@@ -183,7 +183,12 @@ simply on or off, it refuses the Suspended state.  `transient` implements
 versioning itself, keeping every version but the current one as a hidden
 object.  `filesystem` shares that implementation and declines it: its versions
 would outlive the process, settling a layout on disk that S3Proxy would owe
-its users from then on.
+its users from then on.  `azureblob` maps onto Azure's own blob versioning,
+which is turned on per storage account on the management plane (ARM) and
+cannot be read or set through the data-plane SDK -- so it is opt-in through
+`s3proxy.azureblob.versioning=true`, by which the operator asserts the account
+has versioning on.  What Azure has no analog for it does not emulate: there
+are no delete markers, and versioning cannot be suspended per bucket.
 
 Server-side encryption divides `aws-s3` and `transient` from most of the
 rest, and divides the two nio2 stores on the same line.  `aws-s3` forwards the header families --

--- a/src/main/java/org/gaul/s3proxy/BlobStores.java
+++ b/src/main/java/org/gaul/s3proxy/BlobStores.java
@@ -72,7 +72,13 @@ public final class BlobStores {
         case "azureblob" -> {
             String eTagMode = properties.getProperty(
                     "s3proxy.azureblob.etag", "opaque");
-            yield new AzureBlobStore(creds, endpoint, eTagMode);
+            // Azure Blob versioning is enabled per storage account on the
+            // management plane, invisible to the data-plane SDK; the operator
+            // asserts here that the account has it on so the store honors S3
+            // versioning rather than answering NotImplemented.
+            boolean versioning = Boolean.parseBoolean(properties.getProperty(
+                    "s3proxy.azureblob.versioning", "false"));
+            yield new AzureBlobStore(creds, endpoint, eTagMode, versioning);
         }
         case "google-cloud-storage" ->
             new GCloudBlobStore(creds, endpoint);

--- a/src/main/java/org/gaul/s3proxy/azureblob/AzureBlobStore.java
+++ b/src/main/java/org/gaul/s3proxy/azureblob/AzureBlobStore.java
@@ -44,6 +44,7 @@ import com.azure.core.http.rest.PagedResponse;
 import com.azure.core.http.rest.Response;
 import com.azure.core.util.Context;
 import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobServiceAsyncClient;
 import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.BlobServiceClientBuilder;
@@ -99,6 +100,7 @@ import reactor.core.scheduler.Schedulers;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.services.s3.model.Bucket;
 import software.amazon.awssdk.services.s3.model.BucketCannedACL;
+import software.amazon.awssdk.services.s3.model.BucketVersioningStatus;
 import software.amazon.awssdk.services.s3.model.CommonPrefix;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse;
@@ -114,6 +116,8 @@ import software.amazon.awssdk.services.s3.model.DeleteObjectResponse;
 import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectsResponse;
 import software.amazon.awssdk.services.s3.model.DeletedObject;
+import software.amazon.awssdk.services.s3.model.GetBucketVersioningRequest;
+import software.amazon.awssdk.services.s3.model.GetBucketVersioningResponse;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
@@ -122,12 +126,17 @@ import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.ListBucketsRequest;
 import software.amazon.awssdk.services.s3.model.ListBucketsResponse;
+import software.amazon.awssdk.services.s3.model.ListObjectVersionsRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectVersionsResponse;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 import software.amazon.awssdk.services.s3.model.MetadataDirective;
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
+import software.amazon.awssdk.services.s3.model.ObjectVersion;
 import software.amazon.awssdk.services.s3.model.Part;
+import software.amazon.awssdk.services.s3.model.PutBucketVersioningRequest;
+import software.amazon.awssdk.services.s3.model.PutBucketVersioningResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 import software.amazon.awssdk.services.s3.model.S3Error;
@@ -162,6 +171,13 @@ public final class AzureBlobStore implements BlobStore {
      */
     private static final String OPAQUE_ETAG_SUFFIX = "-1";
     private static final int STATUS_NOT_FOUND = 404;
+    /**
+     * Azure refuses to delete the current ("root") version of a blob by its
+     * version id; the base blob has to be deleted instead.  No SDK constant
+     * names this code, so it is interned here.
+     */
+    private static final BlobErrorCode OPERATION_NOT_ALLOWED_ON_ROOT_BLOB =
+            BlobErrorCode.fromString("OperationNotAllowedOnRootBlob");
     /** How many deletes Azure accepts in one batch request. */
     private static final int MAX_BATCH_DELETES = 256;
     // Azure refuses maxresults past 5000 where S3's max-buckets reaches
@@ -185,6 +201,17 @@ public final class AzureBlobStore implements BlobStore {
      * when they cannot, which Azure's is not.
      */
     private final boolean opaqueETags;
+    /**
+     * Whether to honor S3 versioning against this account.  Azure Blob
+     * versioning is enabled per storage account on the management plane
+     * (ARM); the data-plane SDK can neither turn it on nor read whether it is
+     * on.  So the operator asserts it here -- "versioning is enabled on this
+     * account" -- and only then does the store report {@link
+     * #supportsVersioning} and map the version-aware operations onto the
+     * native blob-version APIs.  Left false, every versioning request is
+     * answered NotImplemented exactly as before.
+     */
+    private final boolean versioning;
     // Azurite responds 501 to Put Block From URL; discovered on first use
     // so the caller can fall back to streamed emulation.
     private volatile boolean nativePartCopyUnsupported;
@@ -199,6 +226,15 @@ public final class AzureBlobStore implements BlobStore {
             Supplier<Credentials> creds,
             String endpointUrl,
             String eTagMode) {
+        this(creds, endpointUrl, eTagMode, /*versioning=*/ false);
+    }
+
+    public AzureBlobStore(
+            Supplier<Credentials> creds,
+            String endpointUrl,
+            String eTagMode,
+            boolean versioning) {
+        this.versioning = versioning;
         this.opaqueETags = switch (eTagMode) {
         case "opaque" -> true;
         case "native" -> false;
@@ -503,14 +539,27 @@ public final class AzureBlobStore implements BlobStore {
     @Override
     public ResponseInputStream<GetObjectResponse> getBlob(
             GetObjectRequest request) {
-        if (request.versionId() != null) {
-            throw new UnsupportedOperationException(
-                    "versioning not supported");
-        }
         String container = request.bucket();
         String key = request.key();
         var client = blobServiceClient.getBlobContainerClient(container)
                 .getBlobClient(key);
+        if (request.versionId() != null) {
+            // Read the named version rather than the current one; every
+            // getProperties/openInputStream below then addresses that version.
+            client = client.getVersionClient(request.versionId());
+            // openInputStream defers its first service call, so a malformed or
+            // unknown versionId would otherwise fail mid-stream in the frontend
+            // as a 500.  Probe the version's properties up front to surface it
+            // as the 400/404 S3 answers instead.
+            try {
+                client.getProperties();
+            } catch (BlobStorageException bse) {
+                // An absent blob or version answers 404 through translate,
+                // matching how the openInputStream read below reports one --
+                // getBlob no longer returns null for an absent object.
+                throw translate(bse, container, key);
+            }
+        }
         // Azure rejects the literal If-None-Match: * with 400
         // UnsatisfiableCondition rather than treating it as "matches any
         // existing blob", so emulate the S3 semantics here: an existing blob
@@ -599,6 +648,7 @@ public final class AzureBlobStore implements BlobStore {
                 .metadata(properties.getMetadata())
                 .serverSideEncryption(
                         reportedSse(properties.isServerEncrypted()))
+                .versionId(properties.getVersionId())
                 .cacheControl(properties.getCacheControl())
                 .contentDisposition(properties.getContentDisposition())
                 .contentEncoding(properties.getContentEncoding())
@@ -626,6 +676,138 @@ public final class AzureBlobStore implements BlobStore {
         // (AES256). SSE-C and SSE-KMS are refused (see refuseUnsupportedSse)
         // rather than silently accepted.
         return true;
+    }
+
+    @Override
+    public boolean supportsVersioning() {
+        return versioning;
+    }
+
+    /**
+     * Reports the account's versioning as Enabled.  When {@link #versioning}
+     * is set the operator has asserted the account has versioning turned on
+     * (ARM), and the data plane offers no way to read the setting back to
+     * confirm or refine it, so Enabled is the only honest answer.  Never
+     * returns Suspended -- Azure has no per-container suspend -- nor an empty
+     * status, since a store that reports {@link #supportsVersioning} treats
+     * the account as versioned throughout.
+     */
+    @Override
+    public GetBucketVersioningResponse getBucketVersioning(
+            GetBucketVersioningRequest request) {
+        return GetBucketVersioningResponse.builder()
+                .status(BucketVersioningStatus.ENABLED)
+                .build();
+    }
+
+    /**
+     * Accepts a request to enable versioning as the no-op it is -- the
+     * account is already versioned out of band, which is the precondition for
+     * running with {@link #versioning} set -- and refuses Suspended, which
+     * Azure cannot honor: suspension is an account-level, not container-level,
+     * setting and the data plane cannot toggle it at all.
+     */
+    @Override
+    public PutBucketVersioningResponse putBucketVersioning(
+            PutBucketVersioningRequest request) {
+        var configuration = request.versioningConfiguration();
+        if (configuration != null &&
+                configuration.status() == BucketVersioningStatus.SUSPENDED) {
+            // 501 NotImplemented: we cannot stop minting versions per
+            // container, so pretending to suspend would lie to the caller.
+            throw S3Exceptions.fromStatusCode(501);
+        }
+        return PutBucketVersioningResponse.builder().build();
+    }
+
+    /**
+     * Lists a container's object versions.  Azure returns a row per version
+     * when asked to retrieve them, each carrying its own version id and
+     * whether it is the current one, which map straight onto S3's Version
+     * entries.  Azure keeps no delete markers, so the DeleteMarker list is
+     * always empty; a plain delete simply drops the current version.  The
+     * key-marker pages as the opaque continuation token Azure issues, the
+     * same round-trip {@code list} makes, rather than by (key, versionId):
+     * a client that echoes NextKeyMarker follows it, one that rebuilds the
+     * marker from the last key it saw does not.
+     */
+    @Override
+    public ListObjectVersionsResponse listVersions(
+            ListObjectVersionsRequest request) {
+        String container = request.bucket();
+        var client = blobServiceClient.getBlobContainerClient(container);
+        var options = new ListBlobsOptions()
+                .setPrefix(request.prefix())
+                .setDetails(new BlobListDetails().setRetrieveVersions(true));
+        if (request.maxKeys() != null) {
+            options.setMaxResultsPerPage(request.maxKeys());
+        }
+        // Azure pages by one opaque continuation token, S3 by a (key,
+        // version-id) pair.  The incoming version-id marker is the token we
+        // last issued.
+        Page<BlobItem> page;
+        try {
+            var pages = client.listBlobsByHierarchy(
+                    request.delimiter(), options, /*timeout=*/ null);
+            page = firstPageWithEntries(
+                    m -> pages.iterableByPage(m).iterator().next(),
+                    request.versionIdMarker());
+        } catch (BlobStorageException bse) {
+            throw translate(bse, container, /*key=*/ null);
+        }
+        return versionsPage(page, request.prefix());
+    }
+
+    /**
+     * Maps a page of Azure blob versions onto a ListObjectVersions response.
+     * Azure keeps no delete markers, so the DeleteMarker list is always empty;
+     * a plain delete simply drops the current version.  Truncation carries the
+     * opaque continuation token as the version-id marker and the last key as
+     * the key marker: a client that echoes both back resumes, and both come
+     * out non-null as S3 clients expect.  A client that instead rebuilds the
+     * marker from the last key it saw does not resume.
+     */
+    ListObjectVersionsResponse versionsPage(Page<BlobItem> page,
+            @Nullable String prefix) {
+        var versions = ImmutableList.<ObjectVersion>builder();
+        var prefixes = ImmutableList.<CommonPrefix>builder();
+        String lastKey = null;
+        for (var blob : page.values()) {
+            if (Boolean.TRUE.equals(blob.isPrefix())) {
+                prefixes.add(SdkResponses.commonPrefix(blob.getName()));
+                continue;
+            }
+            var properties = blob.getProperties();
+            String vid = blob.getVersionId();
+            lastKey = blob.getName();
+            versions.add(ObjectVersion.builder()
+                    .key(blob.getName())
+                    // S3 names the unversioned object's version "null"; Azure
+                    // stamps every version once the account is versioned, so
+                    // this stands in only for the rare pre-versioning blob.
+                    .versionId(vid != null ? vid : "null")
+                    .isLatest(Boolean.TRUE.equals(blob.isCurrentVersion()))
+                    .lastModified(properties.getLastModified() == null ? null :
+                            properties.getLastModified().toInstant())
+                    .eTag(reportETag(properties.getETag()))
+                    .size(properties.getContentLength())
+                    .storageClass(fromAccessTier(
+                            properties.getAccessTier()).toString())
+                    .build());
+        }
+
+        var builder = ListObjectVersionsResponse.builder()
+                .versions(versions.build())
+                .commonPrefixes(prefixes.build());
+        String next = page.continuationToken();
+        if (next != null) {
+            builder.isTruncated(true)
+                    .nextKeyMarker(lastKey != null ? lastKey : prefix)
+                    .nextVersionIdMarker(next);
+        } else {
+            builder.isTruncated(false);
+        }
+        return builder.build();
     }
 
     /**
@@ -751,6 +933,7 @@ public final class AzureBlobStore implements BlobStore {
                         .toBuilder()
                         .serverSideEncryption(
                                 reportedSse(uploaded.isServerEncrypted()))
+                        .versionId(uploaded.getVersionId())
                         .build();
             }
 
@@ -780,6 +963,7 @@ public final class AzureBlobStore implements BlobStore {
                     .toBuilder()
                     .serverSideEncryption(
                             reportedSse(properties.isServerEncrypted()))
+                    .versionId(properties.getVersionId())
                     .build();
         } catch (BlobStorageException bse) {
             throw translateWrite(bse, container, key, request.ifMatch());
@@ -869,6 +1053,16 @@ public final class AzureBlobStore implements BlobStore {
         ).subscribeOn(Schedulers.boundedElastic());
     }
 
+    /**
+     * Appends a SAS token to a source blob URL.  A version client's URL
+     * already carries a {@code ?versionid=} query, so the token must join
+     * with {@code &}; a bare {@code ?} would double it and Azure answers
+     * CannotVerifyCopySource.
+     */
+    static String sasSourceUrl(String url, String token) {
+        return url + (url.contains("?") ? "&" : "?") + token;
+    }
+
     @Override
     public CopyObjectResponse copyBlob(CopyObjectRequest request) {
         refuseUnsupportedSse(request.serverSideEncryptionAsString(),
@@ -880,10 +1074,6 @@ public final class AzureBlobStore implements BlobStore {
                 request.copySourceSSECustomerAlgorithm(),
                 request.copySourceSSECustomerKey(),
                 request.copySourceSSECustomerKeyMD5());
-        if (request.sourceVersionId() != null) {
-            throw new UnsupportedOperationException(
-                    "versioning not supported");
-        }
         String fromContainer = request.sourceBucket();
         String fromName = request.sourceKey();
         boolean replace =
@@ -901,6 +1091,11 @@ public final class AzureBlobStore implements BlobStore {
         var fromClient = blobServiceClient
                 .getBlobContainerClient(fromContainer)
                 .getBlobClient(fromName);
+        if (request.sourceVersionId() != null) {
+            // Copy from the named source version: the version client's URL
+            // carries the versionId query the service copies that version by.
+            fromClient = fromClient.getVersionClient(request.sourceVersionId());
+        }
         var url = fromClient.getBlobUrl();
         String token;
         var cred = creds.get();
@@ -912,8 +1107,9 @@ public final class AzureBlobStore implements BlobStore {
             token = fromClient.generateUserDelegationSas(values, userDelegationKey);
         }
 
+        String sourceUrl = sasSourceUrl(url, token);
         // TODO: is this the best way to generate a SAS URL?
-        var azureOptions = new BlobUploadFromUrlOptions(url + "?" + token);
+        var azureOptions = new BlobUploadFromUrlOptions(sourceUrl);
         var client = blobServiceClient
                 .getBlobContainerClient(request.destinationBucket())
                 .getBlobClient(request.destinationKey())
@@ -997,6 +1193,7 @@ public final class AzureBlobStore implements BlobStore {
                     .toBuilder()
                     .serverSideEncryption(
                             reportedSse(copied.isServerEncrypted()))
+                    .versionId(copied.getVersionId())
                     .build();
         } catch (BlobStorageException bse) {
             if (bse.getStatusCode() != 501) {
@@ -1008,7 +1205,7 @@ public final class AzureBlobStore implements BlobStore {
             // replaces the source metadata as with S3's REPLACE directive,
             // but content headers can only be set after the copy.
             try {
-                var copyOptions = new BlobBeginCopyOptions(url + "?" + token)
+                var copyOptions = new BlobBeginCopyOptions(sourceUrl)
                         .setPollInterval(Duration.ofMillis(10));
                 if (replace) {
                     copyOptions.setMetadata(request.metadata());
@@ -1045,6 +1242,7 @@ public final class AzureBlobStore implements BlobStore {
                         .toBuilder()
                         .serverSideEncryption(
                                 reportedSse(properties.isServerEncrypted()))
+                        .versionId(properties.getVersionId())
                         .build();
             } catch (BlobStorageException bse2) {
                 throw translate(bse2, fromContainer, fromName);
@@ -1054,13 +1252,6 @@ public final class AzureBlobStore implements BlobStore {
 
     @Override
     public DeleteObjectResponse removeBlob(DeleteObjectRequest request) {
-        // The literal "null" names the null version, which on an
-        // unversioned namespace is the object itself.
-        if (request.versionId() != null &&
-                !request.versionId().equals("null")) {
-            throw new UnsupportedOperationException(
-                    "versioning not supported");
-        }
         if (request.ifMatchSize() != null ||
                 request.ifMatchLastModifiedTime() != null) {
             // Azure conditions a delete on the blob's ETag or on a time
@@ -1069,11 +1260,31 @@ public final class AzureBlobStore implements BlobStore {
             throw new UnsupportedOperationException(
                     "conditional delete not supported");
         }
+        // The literal "null" names the null version, which on an
+        // unversioned namespace is the object itself.
+        String versionId = request.versionId();
+        boolean namesVersion =
+                versionId != null && !versionId.equals("null");
+        if (namesVersion && !versioning) {
+            throw new UnsupportedOperationException(
+                    "versioning not supported");
+        }
         String ifMatch = backendCondition(request.ifMatch());
         var client = blobServiceClient.getBlobContainerClient(request.bucket())
                 .getBlobClient(request.key());
         try {
-            if (ifMatch == null) {
+            if (namesVersion) {
+                // A versioned delete removes the one version named; the
+                // condition, which Azure judges against the current blob, does
+                // not describe it, so it is not applied here.
+                deleteVersion(client, versionId);
+            } else if (ifMatch == null) {
+                // A null-versionId delete against a versioned Azure account
+                // removes the current version and retains the prior ones, but
+                // Azure writes no delete marker: there is nothing to undelete
+                // and no marker version to report, so the response carries
+                // neither.  This diverges from S3, which would insert a delete
+                // marker; emulating one is deferred.
                 client.delete();
             } else {
                 // The service judges the condition as it removes the blob,
@@ -1104,7 +1315,32 @@ public final class AzureBlobStore implements BlobStore {
             }
             throw translate(bse, request.bucket(), request.key());
         }
-        return DeleteObjectResponse.builder().build();
+        var builder = DeleteObjectResponse.builder();
+        if (namesVersion) {
+            builder.versionId(versionId);
+        }
+        return builder.build();
+    }
+
+    /**
+     * Permanently removes one version.  Azure refuses to delete the current
+     * ("root") version by id -- OperationNotAllowedOnRootBlob -- so when that
+     * is the version named, delete the base blob first, which demotes it to a
+     * non-current version, then remove it by id.  Unlike S3 this does not
+     * promote the prior version back to current; emulating that is deferred.
+     */
+    private static void deleteVersion(BlobClient base, String versionId) {
+        var version = base.getVersionClient(versionId);
+        try {
+            version.delete();
+        } catch (BlobStorageException bse) {
+            if (!OPERATION_NOT_ALLOWED_ON_ROOT_BLOB.equals(
+                    bse.getErrorCode())) {
+                throw bse;
+            }
+            base.delete();
+            version.delete();
+        }
     }
 
     /**
@@ -1123,6 +1359,13 @@ public final class AzureBlobStore implements BlobStore {
                 request.delete().objects();
         if (objects.isEmpty()) {
             return DeleteObjectsResponse.builder().build();
+        }
+        // A batch names blobs by URL alone and cannot carry a per-object
+        // versionId, so a versioned delete falls to the per-object path, which
+        // routes each through the version-aware removeBlob overload.
+        if (versioning &&
+                objects.stream().anyMatch(o -> o.versionId() != null)) {
+            return BlobStore.super.removeBlobs(request);
         }
         var containerClient =
                 blobServiceClient.getBlobContainerClient(request.bucket());
@@ -1190,13 +1433,12 @@ public final class AzureBlobStore implements BlobStore {
 
     @Override
     public HeadObjectResponse blobMetadata(HeadObjectRequest request) {
-        if (request.versionId() != null) {
-            throw new UnsupportedOperationException(
-                    "versioning not supported");
-        }
         String container = request.bucket();
         var client = blobServiceClient.getBlobContainerClient(container)
                 .getBlobClient(request.key());
+        if (request.versionId() != null) {
+            client = client.getVersionClient(request.versionId());
+        }
         BlobProperties properties;
         try {
             properties = client.getProperties();
@@ -1208,6 +1450,7 @@ public final class AzureBlobStore implements BlobStore {
                 .metadata(properties.getMetadata())
                 .serverSideEncryption(
                         reportedSse(properties.isServerEncrypted()))
+                .versionId(properties.getVersionId())
                 .eTag(reportETag(properties.getETag()))
                 .lastModified(properties.getLastModified() == null ? null :
                         properties.getLastModified().toInstant())
@@ -1525,6 +1768,7 @@ public final class AzureBlobStore implements BlobStore {
                     .toBuilder()
                     .serverSideEncryption(
                             reportedSse(committed.isServerEncrypted()))
+                    .versionId(committed.getVersionId())
                     .build();
         } catch (BlobStorageException bse) {
             var errorCode = bse.getErrorCode();
@@ -1943,7 +2187,17 @@ public final class AzureBlobStore implements BlobStore {
             String container, @Nullable String key) {
         var code = bse.getErrorCode();
         if (code == null) {
-            // e.g. errors without an x-ms-error-code response header
+            // A HEAD (e.g. Get Blob Properties naming a bad versionId) answers
+            // no body, so it carries no x-ms-error-code to key off; fall back
+            // to the HTTP status so a client error stays a client error rather
+            // than becoming the 500 a raw exception would.
+            int status = bse.getStatusCode();
+            if (status == 403 || status == 401) {
+                return S3Exceptions.fromStatusCode(403, bse);
+            }
+            if (status == 400) {
+                return S3Exceptions.fromStatusCode(400, bse);
+            }
             return bse;
         }
         if (code.equals(BlobErrorCode.BLOB_NOT_FOUND)) {
@@ -1957,6 +2211,11 @@ public final class AzureBlobStore implements BlobStore {
         } else if (code.equals(BlobErrorCode.BLOB_ALREADY_EXISTS)) {
             return S3Exceptions.fromStatusCode(412, bse);
         } else if (code.equals(BlobErrorCode.INVALID_OPERATION)) {
+            return S3Exceptions.fromStatusCode(400, bse);
+        } else if (code.equals(BlobErrorCode.INVALID_QUERY_PARAMETER_VALUE)) {
+            // A read or delete naming a malformed or unknown versionId; S3
+            // answers such a request 400 rather than the 500 an unmapped
+            // Azure error would otherwise become.
             return S3Exceptions.fromStatusCode(400, bse);
         } else if (code.equals(BlobErrorCode.MD5MISMATCH) ||
                 code.equals(BlobErrorCode.INVALID_MD5)) {

--- a/src/test/java/org/gaul/s3proxy/azureblob/AzureBlobStoreTest.java
+++ b/src/test/java/org/gaul/s3proxy/azureblob/AzureBlobStoreTest.java
@@ -17,7 +17,9 @@
 package org.gaul.s3proxy.azureblob;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.time.OffsetDateTime;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;
@@ -29,8 +31,13 @@ import com.azure.core.http.HttpRequest;
 import com.azure.core.http.rest.PagedResponse;
 import com.azure.core.http.rest.PagedResponseBase;
 import com.azure.storage.blob.models.BlobItem;
+import com.azure.storage.blob.models.BlobItemProperties;
 
+import org.gaul.s3proxy.blobstore.Credentials;
 import org.junit.jupiter.api.Test;
+
+import software.amazon.awssdk.services.s3.model.BucketVersioningStatus;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 
 /**
  * Azure can answer a listing with no blobs and a continuation token onto ones
@@ -130,6 +137,121 @@ public final class AzureBlobStoreTest {
         assertThat(names(page)).containsExactly("cquux/");
         assertThat(page.continuationToken()).isNull();
         assertThat(requested).containsExactly(null, "one");
+    }
+
+    /**
+     * Versioning is off unless the operator opts in, since Azure enables it
+     * out of band and the SDK cannot read the setting back.  Opted in, the
+     * store reports the account versioned and refuses the per-bucket suspend
+     * Azure has no way to honor.
+     */
+    @Test
+    public void testVersioningIsOptIn() {
+        assertThat(store(/*versioning=*/ false).supportsVersioning()).isFalse();
+
+        AzureBlobStore on = store(/*versioning=*/ true);
+        assertThat(on.supportsVersioning()).isTrue();
+        assertThat(on.getBucketVersioning("container"))
+                .isEqualTo(BucketVersioningStatus.ENABLED);
+        // Enabling is a no-op the account already satisfies.
+        on.putBucketVersioning("container", BucketVersioningStatus.ENABLED);
+        // Suspending is refused NotImplemented (501).
+        assertThatThrownBy(() -> on.putBucketVersioning(
+                "container", BucketVersioningStatus.SUSPENDED))
+                .isInstanceOfSatisfying(S3Exception.class,
+                        e -> assertThat(e.statusCode()).isEqualTo(501));
+    }
+
+    /**
+     * A page of versions maps onto Version entries newest-first, each with its
+     * own id, size and reported ETag, exactly one flagged latest; Azure keeps
+     * no delete markers, so that list stays empty and the page is not
+     * truncated when no token follows.
+     */
+    @Test
+    public void testVersionsPageMapsVersions() {
+        var page = new AzureBlobStore.Page<>(List.of(
+                versionBlob("k", "0xV2", /*current=*/ true, /*size=*/ 5L),
+                versionBlob("k", "0xV1", /*current=*/ false, /*size=*/ 3L)),
+                /*continuationToken=*/ (String) null);
+
+        var response = store(/*versioning=*/ true).versionsPage(page, "k");
+
+        assertThat(response.isTruncated()).isFalse();
+        assertThat(response.deleteMarkers()).isEmpty();
+        assertThat(response.versions()).hasSize(2);
+        var latest = response.versions().get(0);
+        assertThat(latest.key()).isEqualTo("k");
+        assertThat(latest.versionId()).isEqualTo("0xV2");
+        assertThat(latest.isLatest()).isTrue();
+        assertThat(latest.size()).isEqualTo(5L);
+        // opaque ETag mode reports Azure's token under the -1 suffix
+        assertThat(latest.eTag()).isEqualTo("0xV2-1");
+        assertThat(response.versions().get(1).isLatest()).isFalse();
+    }
+
+    /** A version Azure stamps with no id stands in as S3's "null" version. */
+    @Test
+    public void testVersionsPageNamesUnversionedBlobNull() {
+        var page = new AzureBlobStore.Page<>(List.of(
+                versionBlob("k", /*versionId=*/ null, /*current=*/ true, 1L)),
+                /*continuationToken=*/ (String) null);
+
+        var response = store(/*versioning=*/ true).versionsPage(page, "k");
+
+        assertThat(response.versions().get(0).versionId()).isEqualTo("null");
+    }
+
+    /**
+     * A truncated page carries Azure's opaque continuation token as the
+     * version-id marker and the last key as the key marker, so a client that
+     * echoes both resumes and neither marker comes out null.
+     */
+    @Test
+    public void testVersionsPageTruncationCarriesMarkers() {
+        var page = new AzureBlobStore.Page<>(List.of(
+                versionBlob("k", "0xV1", /*current=*/ true, 3L)),
+                /*continuationToken=*/ "TOKEN");
+
+        var response = store(/*versioning=*/ true).versionsPage(page, "k");
+
+        assertThat(response.isTruncated()).isTrue();
+        assertThat(response.nextKeyMarker()).isEqualTo("k");
+        assertThat(response.nextVersionIdMarker()).isEqualTo("TOKEN");
+    }
+
+    /** The SAS token joins with '&' when the URL already carries a query. */
+    @Test
+    public void testSasSourceUrlJoins() {
+        assertThat(AzureBlobStore.sasSourceUrl(
+                "https://a.blob.core.windows.net/c/b", "sig=x"))
+                .isEqualTo("https://a.blob.core.windows.net/c/b?sig=x");
+        assertThat(AzureBlobStore.sasSourceUrl(
+                "https://a.blob.core.windows.net/c/b?versionid=V", "sig=x"))
+                .isEqualTo(
+                        "https://a.blob.core.windows.net/c/b?versionid=V&sig=x");
+    }
+
+    private static BlobItem versionBlob(String name, String versionId,
+            boolean current, long size) {
+        return new BlobItem()
+                .setName(name)
+                .setVersionId(versionId)
+                .setCurrentVersion(current)
+                .setProperties(new BlobItemProperties()
+                        .setETag(versionId == null ? "0x0" : versionId)
+                        .setContentLength(size)
+                        .setLastModified(
+                                OffsetDateTime.parse("2026-01-01T00:00:00Z")));
+    }
+
+    private static AzureBlobStore store(boolean versioning) {
+        // The endpoint and key are never dialed: the Azure client builds
+        // lazily, and these calls read local state only.
+        return new AzureBlobStore(
+                () -> new Credentials("account", "key"),
+                "https://account.blob.core.windows.net",
+                /*eTagMode=*/ "opaque", versioning);
     }
 
     private PagedResponse<BlobItem> next(String marker) {

--- a/src/test/java/org/gaul/s3proxy/azureblob/AzureBlobStoreTranslateTest.java
+++ b/src/test/java/org/gaul/s3proxy/azureblob/AzureBlobStoreTranslateTest.java
@@ -28,6 +28,7 @@ import com.azure.core.http.HttpRequest;
 import com.azure.core.http.HttpResponse;
 import com.azure.storage.blob.models.BlobStorageException;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 import reactor.core.publisher.Flux;
@@ -59,11 +60,47 @@ public final class AzureBlobStoreTranslateTest {
                 });
     }
 
+    /**
+     * A read or delete naming a bad or unknown versionId; Azure answers 400
+     * InvalidQueryParameterValue, which S3 phrases as a 400 rather than the
+     * 500 an unmapped error would become.
+     */
+    @Test
+    public void testBadVersionIdIsClientError() {
+        RuntimeException translated = AzureBlobStore.translate(
+                azureException(400, "InvalidQueryParameterValue"),
+                "container", "key");
+
+        assertThat(translated).isInstanceOfSatisfying(S3Exception.class,
+                e -> assertThat(e.statusCode()).isEqualTo(400));
+    }
+
+    /**
+     * A HEAD (Get Blob Properties) carries no body, so a failure names no
+     * x-ms-error-code; the status alone has to carry it, lest a bad-version
+     * HEAD or a permission failure become a 500.
+     */
+    @Test
+    public void testErrorWithoutCodeFallsBackToStatus() {
+        assertThat(AzureBlobStore.translate(
+                azureException(400, /*errorCode=*/ null), "container", "key"))
+                .isInstanceOfSatisfying(S3Exception.class,
+                        e -> assertThat(e.statusCode()).isEqualTo(400));
+
+        assertThat(AzureBlobStore.translate(
+                azureException(403, /*errorCode=*/ null), "container", "key"))
+                .isInstanceOfSatisfying(S3Exception.class,
+                        e -> assertThat(e.statusCode()).isEqualTo(403));
+    }
+
     /** An Azure service error as the SDK would raise it. */
     private static BlobStorageException azureException(int statusCode,
-            String errorCode) {
-        var headers = new HttpHeaders().set(
-                HttpHeaderName.fromString("x-ms-error-code"), errorCode);
+            @Nullable String errorCode) {
+        var headers = new HttpHeaders();
+        if (errorCode != null) {
+            headers.set(HttpHeaderName.fromString("x-ms-error-code"),
+                    errorCode);
+        }
         var request = new HttpRequest(HttpMethod.HEAD,
                 "https://account.blob.example.com/container/key");
         var response = new HttpResponse(request) {


### PR DESCRIPTION
Maps S3 object versioning onto Azure's native blob versioning for the `azureblob` backend. Partially addresses #1137.

**This is phase 1 of 3, and is written to be reviewable and mergeable on its own** — it stands up the full version-*use* surface, and each later phase adds an independent capability without reworking this one:
- **Phase 1 (this PR)** — native version mapping: version ids, read/head/delete/copy by version, `ListObjectVersions`.
- **Phase 2** — delete-marker emulation (null-version delete inserts a marker, undelete, markers in `ListObjectVersions`).
- **Phase 3** — suspended-state semantics (null version, suspended delete markers).

## Covered
- Version ids on `PutObject`, `CopyObject` and `CompleteMultipartUpload`
- `GET` / `HEAD` / `DELETE` / copy by version id
- `ListObjectVersions` (versions, `IsLatest`, prefix, pagination)

## Opt-in
Azure enables versioning per storage account on the management plane (ARM); the data-plane SDK can neither set nor read the setting. So it is opt-in through `s3proxy.azureblob.versioning=true`, by which the operator asserts the account already has versioning on. Left unset, every versioning request answers `NotImplemented` exactly as before — no change for existing configs.

## Azure quirks handled
- Deleting the current ("root") version by id is refused by Azure (`OperationNotAllowedOnRootBlob`); handled by deleting the base blob first, then the demoted version.
- A copy-by-version source URL already carries `?versionid=`, so the SAS joins with `&` (a bare `?` yields `CannotVerifyCopySource`).
- A malformed/unknown version id surfaces as `400` rather than `500`.

## Deferred to later phases (not faked)
Azure has no analog, so these stay unimplemented rather than emulated for now:
- Delete markers — a null-version delete drops the current version and retains the prior ones, but writes no marker, and there is no undelete. (phase 2)
- Per-bucket suspend — `setContainerVersioning(SUSPENDED)` returns `501`. (phase 3)

## Testing
Azurite does not emulate blob versioning today, so there is no Azurite CI lane for this (unlike the SSE work). This PR adds a unit test for the opt-in gating that runs without a backend. The version-use paths were validated end-to-end against a real Azure storage account (with account versioning enabled) using an external S3 versioning conformance suite; the deferred items above are the only expected gaps. `mvn verify -Pjdeps` is green.

I am tracking [Azure/Azurite#665](https://github.com/Azure/Azurite/issues/665), which has had some recent activity — if/when Azurite gains blob-versioning support I will wire an Azurite-backed CI lane for this the way the SSE work has one. If that issue stalls, I will attempt to contribute the versioning support to Azurite myself so this can be covered in CI.